### PR TITLE
Test and implement relative alignment of SVG rects.

### DIFF
--- a/js/SVGPaper-align.js
+++ b/js/SVGPaper-align.js
@@ -1,0 +1,37 @@
+/** Align SVG elemangles.
+*/
+
+function alignLeft_SVGElement(left, elem) {
+    if (!(elem instanceof SVGElement)) { throw "SVGPaper: not implemented for "+el.constructor.name; }
+    elem.setAttributeNS(null,"x",left);
+    return elem;
+}
+
+function alignRight_SVGElement(right, elem) {
+    if (!(elem instanceof SVGElement)) { throw "SVGPaper: not implemented for "+el.constructor.name; }
+    elem.x = right-elem.width;
+    return elem;
+}
+
+function alignTop_SVGElement(toppp, elem) {
+    if (!(elem instanceof SVGElement)) { throw "SVGPaper: not implemented for "+el.constructor.name; }
+    elem.y = toppp;
+    return elem;
+}
+
+function alignBottom_SVGElement(bottom, elem) {
+    if (!(elem instanceof SVGElement)) { throw "SVGPaper: not implemented for "+el.constructor.name; }
+    elem.y = bottom-elem.height;
+    return elem;
+}
+
+function alignrelLeft_SVGElements (elems) {
+    console.log("alignrelLeft_SVGElements:", elems);
+    var left = elems[elems.length-1].x.baseVal.value;  // might be undefined if no elems is empty, but then the loops will never run
+    // find minimum x coordinate
+    for ( var i = 0; i < elems.length; i++)
+        if (left > elems[i].x.baseVal.value) left = elems[i].x.baseVal.value;
+    console.log("left", left);
+    for ( var i = 0; i < elems.length; i++)
+        alignLeft_SVGElement(left, elems[i]);
+}

--- a/js/SVGPaper-align.js
+++ b/js/SVGPaper-align.js
@@ -2,20 +2,20 @@
 */
 
 function alignLeft_SVGElement(left, elem) {
-    if (!(elem instanceof SVGElement)) { throw "SVGPaper: not implemented for "+el.constructor.name; }
+    if (!(elem instanceof SVGElement)) { throw "SVGPaper: not implemented for "+elem.constructor.name; }
     elem.setAttributeNS(null,"x",left);
     return elem;
 }
 
 function alignRight_SVGElement(right, elem) {
-    if (!(elem instanceof SVGElement)) { throw "SVGPaper: not implemented for "+el.constructor.name; }
+    if (!(elem instanceof SVGElement)) { throw "SVGPaper: not implemented for "+elem.constructor.name; }
     elem.x = right-elem.width;
     return elem;
 }
 
 function alignTop_SVGElement(toppp, elem) {
-    if (!(elem instanceof SVGElement)) { throw "SVGPaper: not implemented for "+el.constructor.name; }
-    elem.y = toppp;
+    if (!(elem instanceof SVGElement)) { throw "SVGPaper: not implemented for "+elem.constructor.name; }
+    elem.setAttributeNS(null,"y",toppp);
     return elem;
 }
 
@@ -34,4 +34,15 @@ function alignrelLeft_SVGElements (elems) {
     console.log("left", left);
     for ( var i = 0; i < elems.length; i++)
         alignLeft_SVGElement(left, elems[i]);
+}
+
+function alignrelTop_SVGElements (elems) {
+    console.log("alignreltop_SVGElements:", elems);
+    var toppp = elems[elems.length-1].y.baseVal.value;  // might be undefined if no elems is empty, but then the loops will never run
+    // find minimum y coordinate
+    for ( var i = 0; i < elems.length; i++)
+        if (toppp > elems[i].y.baseVal.value) toppp = elems[i].y.baseVal.value;
+    console.log("toppp", toppp);
+    for ( var i = 0; i < elems.length; i++)
+        alignTop_SVGElement(toppp, elems[i]);
 }

--- a/js/SVGPaper-align.js
+++ b/js/SVGPaper-align.js
@@ -9,7 +9,7 @@ function alignLeft_SVGElement(left, elem) {
 
 function alignRight_SVGElement(right, elem) {
     if (!(elem instanceof SVGElement)) { throw "SVGPaper: not implemented for "+elem.constructor.name; }
-    elem.x = right-elem.width;
+    elem.setAttributeNS(null,"x",right-elem.width.baseVal.value);
     return elem;
 }
 
@@ -21,7 +21,7 @@ function alignTop_SVGElement(toppp, elem) {
 
 function alignBottom_SVGElement(bottom, elem) {
     if (!(elem instanceof SVGElement)) { throw "SVGPaper: not implemented for "+el.constructor.name; }
-    elem.y = bottom-elem.height;
+    elem.setAttributeNS(null,"y",bottom-elem.height.baseVal.value);
     return elem;
 }
 
@@ -36,6 +36,17 @@ function alignrelLeft_SVGElements (elems) {
         alignLeft_SVGElement(left, elems[i]);
 }
 
+function alignrelRight_SVGElements (elems) {
+    console.log("alignrelLeft_SVGElements:", elems);
+    var right = elems[elems.length-1].x.baseVal.value;  // might be undefined if no elems is empty, but then the loops will never run
+    // find maximum x coordinate of all right edges
+    for ( var i = 0; i < elems.length; i++)
+        if (right < (elems[i].x.baseVal.value+elems[i].width.baseVal.value)) right = elems[i].x.baseVal.value+elems[i].width.baseVal.value;
+    console.log("right", right);
+    for ( var i = 0; i < elems.length; i++)
+        alignRight_SVGElement(right, elems[i]);
+}
+
 function alignrelTop_SVGElements (elems) {
     console.log("alignreltop_SVGElements:", elems);
     var toppp = elems[elems.length-1].y.baseVal.value;  // might be undefined if no elems is empty, but then the loops will never run
@@ -45,4 +56,15 @@ function alignrelTop_SVGElements (elems) {
     console.log("toppp", toppp);
     for ( var i = 0; i < elems.length; i++)
         alignTop_SVGElement(toppp, elems[i]);
+}
+
+function alignrelBottom_SVGElements (elems) {
+    console.log("alignrelLeft_SVGElements:", elems);
+    var bottom = elems[elems.length-1].y.baseVal.value;  // might be undefined if no elems is empty, but then the loops will never run
+    // find maximum y coordinate of all bottom edges
+    for ( var i = 0; i < elems.length; i++)
+        if (bottom < (elems[i].y.baseVal.value+elems[i].height.baseVal.value)) bottom = elems[i].y.baseVal.value+elems[i].height.baseVal.value;
+    console.log("bottom", bottom);
+    for ( var i = 0; i < elems.length; i++)
+        alignBottom_SVGElement(bottom, elems[i]);
 }

--- a/js/SVGPaper-align.js
+++ b/js/SVGPaper-align.js
@@ -1,4 +1,4 @@
-/** Align SVG elemangles.
+/** Align SVG elements.
 */
 
 function alignLeft_SVGElement(left, elem) {
@@ -31,7 +31,6 @@ function alignrelLeft_SVGElements (elems) {
     // find minimum x coordinate
     for ( var i = 0; i < elems.length; i++)
         if (left > elems[i].x.baseVal.value) left = elems[i].x.baseVal.value;
-    console.log("left", left);
     for ( var i = 0; i < elems.length; i++)
         alignLeft_SVGElement(left, elems[i]);
 }
@@ -42,7 +41,6 @@ function alignrelRight_SVGElements (elems) {
     // find maximum x coordinate of all right edges
     for ( var i = 0; i < elems.length; i++)
         if (right < (elems[i].x.baseVal.value+elems[i].width.baseVal.value)) right = elems[i].x.baseVal.value+elems[i].width.baseVal.value;
-    console.log("right", right);
     for ( var i = 0; i < elems.length; i++)
         alignRight_SVGElement(right, elems[i]);
 }
@@ -53,7 +51,6 @@ function alignrelTop_SVGElements (elems) {
     // find minimum y coordinate
     for ( var i = 0; i < elems.length; i++)
         if (toppp > elems[i].y.baseVal.value) toppp = elems[i].y.baseVal.value;
-    console.log("toppp", toppp);
     for ( var i = 0; i < elems.length; i++)
         alignTop_SVGElement(toppp, elems[i]);
 }
@@ -64,7 +61,6 @@ function alignrelBottom_SVGElements (elems) {
     // find maximum y coordinate of all bottom edges
     for ( var i = 0; i < elems.length; i++)
         if (bottom < (elems[i].y.baseVal.value+elems[i].height.baseVal.value)) bottom = elems[i].y.baseVal.value+elems[i].height.baseVal.value;
-    console.log("bottom", bottom);
     for ( var i = 0; i < elems.length; i++)
         alignBottom_SVGElement(bottom, elems[i]);
 }

--- a/js/clip8.js
+++ b/js/clip8.js
@@ -25,7 +25,14 @@ function clip8envokeOperation() {
     console.log("ELS:", els, els.length);
 
     if          ( oper[0].classList.contains("clip8alignrel") ) {
-        alignrelLeft_SVGElements(els);
+        if (!(oper[0] instanceof SVGLineElement)) { throw "[clip8] OP alignrel must be SVGLineElement."; }
+        switch (clip8directionOfSVGLine(oper[0])) {
+            case "top":  alignrelTop_SVGElements(els); break;
+            case "bottom":
+            case "left": alignrelLeft_SVGElements(els); break;
+            case "right":
+        }
+
     }
     else if     ( oper[0].classList.contains("clip8cut") ) {
         throw "clip8cut not implemented.";

--- a/js/clip8.js
+++ b/js/clip8.js
@@ -27,10 +27,10 @@ function clip8envokeOperation() {
     if          ( oper[0].classList.contains("clip8alignrel") ) {
         if (!(oper[0] instanceof SVGLineElement)) { throw "[clip8] OP alignrel must be SVGLineElement."; }
         switch (clip8directionOfSVGLine(oper[0])) {
-            case "top":  alignrelTop_SVGElements(els); break;
-            case "bottom":
-            case "left": alignrelLeft_SVGElements(els); break;
-            case "right":
+            case "top":     alignrelTop_SVGElements(els); break;
+            case "bottom":  alignrelBottom_SVGElements(els); break;
+            case "left":    alignrelLeft_SVGElements(els); break;
+            case "right":   alignrelRight_SVGElements(els); break;
         }
 
     }

--- a/js/clip8.js
+++ b/js/clip8.js
@@ -24,7 +24,7 @@ function clip8envokeOperation() {
             els.push(svgroot.childNodes[i]);
     console.log("ELS:", els, els.length);
 
-    if          ( oper[0].classList.contains("clip8alignrel") ) {
+    if ( oper[0].classList.contains("clip8alignrel") ) {
         if (!(oper[0] instanceof SVGLineElement)) { throw "[clip8] OP alignrel must be SVGLineElement."; }
         switch (clip8directionOfSVGLine(oper[0])) {
             case "top":     alignrelTop_SVGElements(els); break;
@@ -32,9 +32,8 @@ function clip8envokeOperation() {
             case "left":    alignrelLeft_SVGElements(els); break;
             case "right":   alignrelRight_SVGElements(els); break;
         }
-
     }
-    else if     ( oper[0].classList.contains("clip8cut") ) {
+    else if ( oper[0].classList.contains("clip8cut") ) {
         throw "clip8cut not implemented.";
     }
 }

--- a/js/clip8.js
+++ b/js/clip8.js
@@ -17,4 +17,17 @@ function clip8envokeOperation() {
     for ( var i = 0; i < oper.length; i++ ) {
         svgroot.removeChild(oper[i]);
     }
+
+    var els = [];
+    for ( var i = 0; i < svgroot.childNodes.length; i++ )
+        if ( svgroot.childNodes[i] instanceof SVGElement )
+            els.push(svgroot.childNodes[i]);
+    console.log("ELS:", els, els.length);
+
+    if          ( oper[0].classList.contains("clip8alignrel") ) {
+        alignrelLeft_SVGElements(els);
+    }
+    else if     ( oper[0].classList.contains("clip8cut") ) {
+        throw "clip8cut not implemented.";
+    }
 }

--- a/js/clip8decode.js
+++ b/js/clip8decode.js
@@ -1,0 +1,15 @@
+
+function clip8directionOfSVGLine(line) {
+    if          (line.x1.baseVal.value == line.x2.baseVal.value) {
+        // exactly vertical
+        if      (line.y1.baseVal.value < line.y2.baseVal.value) return "bottom";
+        else if (line.y1.baseVal.value > line.y2.baseVal.value) return "top";
+        else throw "[clip8] invalid direction of line (a).";
+    } else if   (line.y1.baseVal.value == line.y2.baseVal.value) {
+        // exactly horizontal
+        if      (line.x1.baseVal.value < line.x2.baseVal.value) return "right";
+        else if (line.x1.baseVal.value > line.x2.baseVal.value) return "left";
+        else throw "[clip8] invalid direction of line (b).";
+    } else throw "[clip8] Direction of non-vertical or non-horizontal lines not implemented.";
+    return "vertical"
+}

--- a/tests/test_SVGPaper-refsheetA.html
+++ b/tests/test_SVGPaper-refsheetA.html
@@ -13,6 +13,7 @@
 <script src="../lib/jasmine-2.5/jasmine-html.js"></script>
 <script src="../lib/jasmine-2.5/boot.js"></script>
 <script src="../js/SVGPaper-align.js"></script>
+<script src="../js/clip8decode.js"></script>
 <script src="../js/clip8.js"></script>
 </head>
 

--- a/tests/test_SVGPaper-refsheetA.html
+++ b/tests/test_SVGPaper-refsheetA.html
@@ -137,6 +137,32 @@
 </span>
 </p>
 
+<div>right:</div>
+<p class="DOMreftest envokeOperation" id="align-right">
+<span class="pre-reference">
+<svg viewbox="-2 -2 68 68" width="68" height="68">
+<rect class="value" x="16" y="7" width="10" height="20"/>
+<rect class="value" x="42" y="30" width="14" height="20"/>
+<line class="clip8OP clip8alignrel" x1="10" y1="55" x2="50" y2="55" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="-2 -2 68 68" width="68" height="68">
+<rect class="value" x="46" y="7" width="10" height="20"/>
+<rect class="value" x="42" y="30" width="14" height="20"/>
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="-2 -2 68 68" width="68" height="68">
+<rect class="value" x="16" y="7" width="10" height="20"/>
+<rect class="value" x="42" y="30" width="14" height="20"/>
+<line class="clip8OP clip8alignrel" x1="10" y1="55" x2="50" y2="55" />
+</svg>
+</span>
+</p>
+
 <div>top:</div>
 <p class="DOMreftest envokeOperation" id="align-top">
 <span class="pre-reference">
@@ -162,6 +188,33 @@
 </svg>
 </span>
 </p>
+
+<div>bottom:</div>
+<p class="DOMreftest envokeOperation" id="align-bottom">
+<span class="pre-reference">
+<svg viewbox="-2 -2 68 68" width="68" height="68">
+<rect class="value" x="16" y="34" width="10" height="20"/>
+<rect class="value" x="42" y="13" width="10" height="29"/>
+<line class="clip8OP clip8alignrel" x1="10" y1="10" x2="10" y2="55" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="-2 -2 68 68" width="68" height="68">
+<rect class="value" x="16" y="34" width="10" height="20"/>
+<rect class="value" x="42" y="25" width="10" height="29"/>
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="-2 -2 68 68" width="68" height="68">
+<rect class="value" x="16" y="34" width="10" height="20"/>
+<rect class="value" x="42" y="13" width="10" height="29"/>
+<line class="clip8OP clip8alignrel" x1="10" y1="10" x2="10" y2="55" />
+</svg>
+</span>
+</p>
+
 <script src="../spec/spec_DOMrefsheet.js"></script>
 
 </body>

--- a/tests/test_SVGPaper-refsheetA.html
+++ b/tests/test_SVGPaper-refsheetA.html
@@ -98,9 +98,7 @@
 <svg width=".5em" height=".5em">
 <defs>
 <marker id="clip8alignrel-start" viewBox="0 0 20 20" refX="10" refY="10" class="clip8alignrel-marker" orient="auto">
-<line x1="18" y1="10" x2="0" y2="2"/>
-<line x1="18" y1="10" x2="0" y2="18"/>
-<line x1="2" y1="2" x2="2" y2="18"/>
+<polygon points="18,10 0,2 0,18"/>
 </marker>
 <marker id="clip8alignrel-end" viewBox="0 0 12 12" refX="6" refY="6" class="clip8alignrel-marker" orient="auto">
 <line x1="6" y1="0" x2="6" y2="12"/>

--- a/tests/test_SVGPaper-refsheetA.html
+++ b/tests/test_SVGPaper-refsheetA.html
@@ -12,6 +12,7 @@
 <script src="../lib/jasmine-2.5/jasmine.js"></script>
 <script src="../lib/jasmine-2.5/jasmine-html.js"></script>
 <script src="../lib/jasmine-2.5/boot.js"></script>
+<script src="../js/SVGPaper-align.js"></script>
 <script src="../js/clip8.js"></script>
 </head>
 


### PR DESCRIPTION
Key ingredients:
Define a DOM reference test for each direction (two boxes to be aligned left, right, top, bottom).
Collect svg elements defining the operations.
Collect svg elements to be aligned, currently all non-operations-elements under #svgroot.
Determine the direction of the OP line.
Determine the leftmost, rightmost etc postion.
Move all elements accordingly.

