### PR TITLE
Refactor execution main loop to be timer event driven.

### DIFF
--- a/js/clip8.js
+++ b/js/clip8.js
@@ -5,7 +5,6 @@ var epsilon = 0.5;  // maximal difference for two coordinates to be considered e
 var minlen = 1.5;     // minimal size of a graphics element to be "meaningful"
 
 var Clip8 = {
-    teminate: false,
     exectimer: null,
     initControlFlow: function (svgroot, tracesvgroot) {
         var debug = false;
@@ -70,11 +69,6 @@ var Clip8 = {
     },
 
     executeOneOperation: function(ip, svgroot, tracesvgroot) {
-        if (Clip8.teminate) {
-            console.log("terminate");
-            return;
-        }
-        console.log("running");
         var debug = false;
         if (debug) console.log("clip8envokeOperation: IP", ip);
         var instrNsel = Clip8.getPrimInstruction(ip, svgroot)
@@ -139,7 +133,7 @@ var Clip8 = {
         tracesvgroot.appendChild(instr1);
         tracesvgroot.appendChild(sel1);
         if (debug) console.log("clip8envokeOperation: removed instr1, sel1", instr1, sel1);
-        Clip8.teminate = true;
+        Clip8.clearExecTimer();
     },
 
     envokeOperation: function () {
@@ -154,10 +148,13 @@ var Clip8 = {
         svgroot.parentNode.appendChild(tracesvgroot);
         tracesvgroot.setAttribute("style", "margin-left:-64; background:none;");
         var ip = Clip8.initControlFlow(svgroot, tracesvgroot);     // instruction pointer: the active control flow path
-        Clip8.teminate = false;
-        var exect = setInterval( function() { Clip8.executeOneOperation(ip, svgroot, tracesvgroot) }, 100 );
+        Clip8.exectimer = setInterval( function() { Clip8.executeOneOperation(ip, svgroot, tracesvgroot) }, 100 );
         var erasetracetimer = setInterval( function() { eraseTrace(tracesvgroot) }, 60 );
-        setTimeout ( function () { clearInterval(erasetracetimer) }, 10000 );   // stop erasor after some time
+        setTimeout ( function () { clearInterval(erasetracetimer); }, 1000 );   // stop erasor after some time
+    },
+
+    clearExecTimer: function () {
+        clearInterval(Clip8.exectimer);
     }
 };
 

--- a/js/clip8.js
+++ b/js/clip8.js
@@ -5,6 +5,8 @@ var epsilon = 0.5;  // maximal difference for two coordinates to be considered e
 var minlen = 1.5;     // minimal size of a graphics element to be "meaningful"
 
 var Clip8 = {
+    teminate: false,
+    exectimer: null,
     initControlFlow: function (svgroot, tracesvgroot) {
         var debug = false;
         var circles = svgroot.getElementsByTagName("circle");
@@ -68,6 +70,11 @@ var Clip8 = {
     },
 
     executeOneOperation: function(ip, svgroot, tracesvgroot) {
+        if (Clip8.teminate) {
+            console.log("terminate");
+            return;
+        }
+        console.log("running");
         var debug = false;
         if (debug) console.log("clip8envokeOperation: IP", ip);
         var instrNsel = Clip8.getPrimInstruction(ip, svgroot)
@@ -132,6 +139,7 @@ var Clip8 = {
         tracesvgroot.appendChild(instr1);
         tracesvgroot.appendChild(sel1);
         if (debug) console.log("clip8envokeOperation: removed instr1, sel1", instr1, sel1);
+        Clip8.teminate = true;
     },
 
     envokeOperation: function () {
@@ -146,9 +154,8 @@ var Clip8 = {
         svgroot.parentNode.appendChild(tracesvgroot);
         tracesvgroot.setAttribute("style", "margin-left:-64; background:none;");
         var ip = Clip8.initControlFlow(svgroot, tracesvgroot);     // instruction pointer: the active control flow path
-
-        Clip8.executeOneOperation(ip, svgroot, tracesvgroot);
-
+        Clip8.teminate = false;
+        var exect = setInterval( function() { Clip8.executeOneOperation(ip, svgroot, tracesvgroot) }, 100 );
         var erasetracetimer = setInterval( function() { eraseTrace(tracesvgroot) }, 60 );
         setTimeout ( function () { clearInterval(erasetracetimer) }, 10000 );   // stop erasor after some time
     }

--- a/js/clip8.js
+++ b/js/clip8.js
@@ -4,148 +4,150 @@
 var epsilon = 0.5;  // maximal difference for two coordinates to be considered equal
 var minlen = 1.5;     // minimal size of a graphics element to be "meaningful"
 
-function clip8initControlFlow(svgroot, tracesvgroot) {
-    var debug = false;
-    var circles = svgroot.getElementsByTagName("circle");
-    var centres = svgdom_addGroup(svgroot);
-    var initialflow = null;
+var Clip8 = {
+    initControlFlow: function (svgroot, tracesvgroot) {
+        var debug = false;
+        var circles = svgroot.getElementsByTagName("circle");
+        var centres = svgdom_addGroup(svgroot);
+        var initialflow = null;
 
-    for ( var i = 0; i < circles.length; i++ ) {
-        var r = svgdom_CentreArea(circles[i], epsilon);
-        r.setAttribute("fill", "#ffff33");
-        centres.appendChild(r);
-    }
-    for ( var i = 0; i < centres.childNodes.length; i++ ) {
-        var sel = svgretrieve_selectorFromRect(centres.childNodes[i], svgroot);
-        var hitlist = svgroot.getIntersectionList(sel, centres);
-        if (debug)  console.log("clip8initControlFlow: hitlist", hitlist);
-        if (hitlist.length == 1) {
-            var initarea = svgretrieve_selectorFromRect(hitlist[0], svgroot);
-            // visualise initial control flow node
-            var tracerect = svgdom_addRect(tracesvgroot, initarea.x-3,initarea.y-3, initarea.width+6, initarea.height+6);
-            clip8setTraceAttribs(tracerect);
-            svgroot.removeChild(centres);
-            hitlist = svgroot.getIntersectionList(initarea, svgroot);
-            if (debug)  console.log("clip8initControlFlow: initiallocation", hitlist);
-            break;
+        for ( var i = 0; i < circles.length; i++ ) {
+            var r = svgdom_CentreArea(circles[i], epsilon);
+            r.setAttribute("fill", "#ffff33");
+            centres.appendChild(r);
         }
-    }
-    if (debug) console.log("clip8initControlFlow: els at initial location.", hitlist);
-    for ( var i = 0; i < hitlist.length; i++ )
-        if (hitlist[i].tagName == "path") return hitlist[i];
-    throw "Failed to idendify point of entry."
-}
-
-function clip8getPrimInstruction (ip, svgroot) {
-    var debug = false;
-    if (debug) console.log("clip8getPrimInstruction", ip, svgroot);
-    if (!(ip.tagName == "path"))
-        throw "[clip8] ip element is not a path.";
-    var endarearect = svgdom_EndOfPathArea(ip, epsilon);
-    endarearect.setAttribute("fill", "#FFEE22");
-    if (debug) console.log("end of path area rect", endarearect);
-    svgroot.appendChild(endarearect);
-    var endarea = svgretrieve_selectorFromRect(endarearect, svgroot);
-    svgroot.removeChild(endarearect);
-    var hitlist = svgroot.getIntersectionList(endarea, svgroot);
-    if (debug) console.log("clip8getPrimInstruction: hitlist", hitlist);
-    if (hitlist.length == 0) throw " ip element is not a path.";
-    var sel = svgdom_addGroup(svgroot);
-    var instr1 = svgdom_addGroup(svgroot);
-    for ( var i = 0; i < hitlist.length; i++ )
-        if (hitlist[i].getAttribute("stroke-linecap") == "round" ||
-            hitlist[i].tagName == "circle") {
-            instr1.appendChild(hitlist[i].cloneNode(false));
-            instr1.lastElementChild.setAttribute("stroke", "#fff");
-        }
-        else if (hitlist[i].getAttribute("stroke-dasharray") &&
-            hitlist[i].tagName == "rect") {
-            sel.appendChild(hitlist[i].cloneNode(false));
-            sel.lastElementChild.setAttribute("stroke", "#fff");
-        }
-    return [instr1,sel];
-}
-
-function clip8envokeOperation() {
-    var debug = true;
-    var svgroot = document.getElementById("clip8svgroot");
-    console.log("clip8envokeOperation:", svgroot);
-    if (!(svgroot instanceof SVGElement)) { throw "[clip8] no SVG root."; }
-
-    svgdom_setSVGNS(svgroot.namespaceURI);
-
-    var tracesvgroot = svgroot.cloneNode(false);
-    svgroot.parentNode.appendChild(tracesvgroot);
-    tracesvgroot.setAttribute("style", "margin-left:-64; background:none;");
-    var ip = clip8initControlFlow(svgroot, tracesvgroot);     // instruction pointer: the active control flow path
-
-        if (debug) console.log("clip8envokeOperation: IP", ip);
-        var instrNsel = clip8getPrimInstruction(ip, svgroot)
-        var instr1 = instrNsel[0];
-        var sel1 = instrNsel[1];
-        if (debug) console.log("clip8envokeOperation: INSTR1, SEL1", instr1, sel1);
-
-        // List of selected Elements based on primary selector
-        var selectedelements1 = [];
-        if (sel1.firstChild instanceof SVGRectElement) {
-            var s = svgretrieve_selectorFromRect(sel1.firstChild, svgroot);
-            if (debug) console.log("clip8envokeOperation: selector from rect in sel1", s);
-            var hitlist = svgroot.getEnclosureList(s, svgroot);
-            for ( var i = 0; i < hitlist.length; i++ )
-                if ( hitlist[i].tagName == "rect" &&
-                     (!hitlist[i].getAttribute("stroke") || hitlist[i].getAttribute("stroke")!= "none") )
-                     selectedelements1.push(hitlist[i]);
-        }
-        else selectedelements1 = undefined;
-
-        if (debug) console.log("clip8envokeOperation: selectedelements1", selectedelements1);
-
-        // decode instruction
-        var signature = clip8countTags(instr1, ["circle", "path", "rect", "line", "polyline"]);
-        if (debug) console.log("clip8envokeOperation: signature", signature);
-        if ( signature.toString() === [2, 0, 0, 0, 0].toString() ) {
-            if (debug) console.log("clip8envokeOperation: two circles");
-            if (instr1.childNodes[0].tagName == "circle" &&
-                instr1.childNodes[1].tagName == "circle") {
-                if (debug) console.log("clip8envokeOperation: TERMINAL.");
-            }
-            else throw "Could not decode instruction A"+instr1;
-        }
-        else if ( signature.toString() === [0, 0, 0, 1, 1].toString() ) {
-            if (debug) console.log("clip8envokeOperation: 1 line, 1 polyline.");
-            var theline = instr1.getElementsByTagName("line")[0];
-            var linedir = clip8directionOfSVGLine(theline, epsilon, minlen);
-            if (debug) console.log("clip8envokeOperation: direction", linedir);
-            var thepoly = instr1.getElementsByTagName("polyline")[0];
-            var angledir = clip8directionOfPolyAngle(thepoly, epsilon, minlen);
-            if (debug) console.log("clip8envokeOperation: angle direction", angledir);
-            switch (linedir) {
-                case 'UP':
-                case 'DOWN':
-                    if (angledir == 'LEFT')         paperclip_alignrelLeft (selectedelements1);
-                    else if (angledir == 'RIGHT')   paperclip_alignrelRight (selectedelements1);
-                    else throw "[clip8envokeOperation] Encountered invalid line arrow combination (a).";
-                    break;
-                case 'LEFT':
-                case 'RIGHT':
-                    if (angledir == 'UP')           paperclip_alignrelTop (selectedelements1);
-                    else if (angledir == 'DOWN')    paperclip_alignrelBottom (selectedelements1);
-                    else throw "[clip8envokeOperation] Encountered invalid line arrow combination (b).";
-                    break;
-                default:        throw "[clip8envokeOperation] Encountered invalid line direction (a)."; break;
+        for ( var i = 0; i < centres.childNodes.length; i++ ) {
+            var sel = svgretrieve_selectorFromRect(centres.childNodes[i], svgroot);
+            var hitlist = svgroot.getIntersectionList(sel, centres);
+            if (debug)  console.log("clip8initControlFlow: hitlist", hitlist);
+            if (hitlist.length == 1) {
+                var initarea = svgretrieve_selectorFromRect(hitlist[0], svgroot);
+                // visualise initial control flow node
+                var tracerect = svgdom_addRect(tracesvgroot, initarea.x-3,initarea.y-3, initarea.width+6, initarea.height+6);
+                clip8setTraceAttribs(tracerect);
+                svgroot.removeChild(centres);
+                hitlist = svgroot.getIntersectionList(initarea, svgroot);
+                if (debug)  console.log("clip8initControlFlow: initiallocation", hitlist);
+                break;
             }
         }
-        else
-            throw "Could not decode instruction X"+instr1;
-        svgroot.removeChild(instr1);
-        svgroot.removeChild(sel1);
-        tracesvgroot.appendChild(instr1);
-        tracesvgroot.appendChild(sel1);
-        if (debug) console.log("clip8envokeOperation: removed instr1, sel1", instr1, sel1);
+        if (debug) console.log("clip8initControlFlow: els at initial location.", hitlist);
+        for ( var i = 0; i < hitlist.length; i++ )
+            if (hitlist[i].tagName == "path") return hitlist[i];
+        throw "Failed to idendify point of entry."
+    },
 
-    var erasetracetimer = setInterval( function() { eraseTrace(tracesvgroot) }, 60 );
-    setTimeout ( function () { clearInterval(erasetracetimer) }, 10000 );   // stop erasor after some time
-}
+    getPrimInstruction: function (ip, svgroot) {
+        var debug = false;
+        if (debug) console.log("clip8getPrimInstruction", ip, svgroot);
+        if (!(ip.tagName == "path"))
+            throw "[clip8] ip element is not a path.";
+        var endarearect = svgdom_EndOfPathArea(ip, epsilon);
+        endarearect.setAttribute("fill", "#FFEE22");
+        if (debug) console.log("end of path area rect", endarearect);
+        svgroot.appendChild(endarearect);
+        var endarea = svgretrieve_selectorFromRect(endarearect, svgroot);
+        svgroot.removeChild(endarearect);
+        var hitlist = svgroot.getIntersectionList(endarea, svgroot);
+        if (debug) console.log("clip8getPrimInstruction: hitlist", hitlist);
+        if (hitlist.length == 0) throw " ip element is not a path.";
+        var sel = svgdom_addGroup(svgroot);
+        var instr1 = svgdom_addGroup(svgroot);
+        for ( var i = 0; i < hitlist.length; i++ )
+            if (hitlist[i].getAttribute("stroke-linecap") == "round" ||
+                hitlist[i].tagName == "circle") {
+                instr1.appendChild(hitlist[i].cloneNode(false));
+                instr1.lastElementChild.setAttribute("stroke", "#fff");
+            }
+            else if (hitlist[i].getAttribute("stroke-dasharray") &&
+                hitlist[i].tagName == "rect") {
+                sel.appendChild(hitlist[i].cloneNode(false));
+                sel.lastElementChild.setAttribute("stroke", "#fff");
+            }
+        return [instr1,sel];
+    },
+
+    envokeOperation: function () {
+        var debug = true;
+        var svgroot = document.getElementById("clip8svgroot");
+        console.log("clip8envokeOperation:", svgroot);
+        if (!(svgroot instanceof SVGElement)) { throw "[clip8] no SVG root."; }
+
+        svgdom_setSVGNS(svgroot.namespaceURI);
+
+        var tracesvgroot = svgroot.cloneNode(false);
+        svgroot.parentNode.appendChild(tracesvgroot);
+        tracesvgroot.setAttribute("style", "margin-left:-64; background:none;");
+        var ip = Clip8.initControlFlow(svgroot, tracesvgroot);     // instruction pointer: the active control flow path
+
+            if (debug) console.log("clip8envokeOperation: IP", ip);
+            var instrNsel = Clip8.getPrimInstruction(ip, svgroot)
+            var instr1 = instrNsel[0];
+            var sel1 = instrNsel[1];
+            if (debug) console.log("clip8envokeOperation: INSTR1, SEL1", instr1, sel1);
+
+            // List of selected Elements based on primary selector
+            var selectedelements1 = [];
+            if (sel1.firstChild instanceof SVGRectElement) {
+                var s = svgretrieve_selectorFromRect(sel1.firstChild, svgroot);
+                if (debug) console.log("clip8envokeOperation: selector from rect in sel1", s);
+                var hitlist = svgroot.getEnclosureList(s, svgroot);
+                for ( var i = 0; i < hitlist.length; i++ )
+                    if ( hitlist[i].tagName == "rect" &&
+                         (!hitlist[i].getAttribute("stroke") || hitlist[i].getAttribute("stroke")!= "none") )
+                         selectedelements1.push(hitlist[i]);
+            }
+            else selectedelements1 = undefined;
+
+            if (debug) console.log("clip8envokeOperation: selectedelements1", selectedelements1);
+
+            // decode instruction
+            var signature = clip8countTags(instr1, ["circle", "path", "rect", "line", "polyline"]);
+            if (debug) console.log("clip8envokeOperation: signature", signature);
+            if ( signature.toString() === [2, 0, 0, 0, 0].toString() ) {
+                if (debug) console.log("clip8envokeOperation: two circles");
+                if (instr1.childNodes[0].tagName == "circle" &&
+                    instr1.childNodes[1].tagName == "circle") {
+                    if (debug) console.log("clip8envokeOperation: TERMINAL.");
+                }
+                else throw "Could not decode instruction A"+instr1;
+            }
+            else if ( signature.toString() === [0, 0, 0, 1, 1].toString() ) {
+                if (debug) console.log("clip8envokeOperation: 1 line, 1 polyline.");
+                var theline = instr1.getElementsByTagName("line")[0];
+                var linedir = clip8directionOfSVGLine(theline, epsilon, minlen);
+                if (debug) console.log("clip8envokeOperation: direction", linedir);
+                var thepoly = instr1.getElementsByTagName("polyline")[0];
+                var angledir = clip8directionOfPolyAngle(thepoly, epsilon, minlen);
+                if (debug) console.log("clip8envokeOperation: angle direction", angledir);
+                switch (linedir) {
+                    case 'UP':
+                    case 'DOWN':
+                        if (angledir == 'LEFT')         paperclip_alignrelLeft (selectedelements1);
+                        else if (angledir == 'RIGHT')   paperclip_alignrelRight (selectedelements1);
+                        else throw "[clip8envokeOperation] Encountered invalid line arrow combination (a).";
+                        break;
+                    case 'LEFT':
+                    case 'RIGHT':
+                        if (angledir == 'UP')           paperclip_alignrelTop (selectedelements1);
+                        else if (angledir == 'DOWN')    paperclip_alignrelBottom (selectedelements1);
+                        else throw "[clip8envokeOperation] Encountered invalid line arrow combination (b).";
+                        break;
+                    default:        throw "[clip8envokeOperation] Encountered invalid line direction (a)."; break;
+                }
+            }
+            else
+                throw "Could not decode instruction X"+instr1;
+            svgroot.removeChild(instr1);
+            svgroot.removeChild(sel1);
+            tracesvgroot.appendChild(instr1);
+            tracesvgroot.appendChild(sel1);
+            if (debug) console.log("clip8envokeOperation: removed instr1, sel1", instr1, sel1);
+
+        var erasetracetimer = setInterval( function() { eraseTrace(tracesvgroot) }, 60 );
+        setTimeout ( function () { clearInterval(erasetracetimer) }, 10000 );   // stop erasor after some time
+    }
+};
 
 function eraseTrace (svgroot) {
     var itemopacity;

--- a/js/clip8.js
+++ b/js/clip8.js
@@ -78,8 +78,7 @@ function clip8envokeOperation() {
     svgroot.parentNode.appendChild(tracesvgroot);
     tracesvgroot.setAttribute("style", "margin-left:-64; background:none;");
     var ip = clip8initControlFlow(svgroot, tracesvgroot);     // instruction pointer: the active control flow path
-    var running = true;
-    while (running) {
+
         if (debug) console.log("clip8envokeOperation: IP", ip);
         var instrNsel = clip8getPrimInstruction(ip, svgroot)
         var instr1 = instrNsel[0];
@@ -109,7 +108,6 @@ function clip8envokeOperation() {
             if (instr1.childNodes[0].tagName == "circle" &&
                 instr1.childNodes[1].tagName == "circle") {
                 if (debug) console.log("clip8envokeOperation: TERMINAL.");
-                running = false; // two concentric circles: terminal.
             }
             else throw "Could not decode instruction A"+instr1;
         }
@@ -136,7 +134,6 @@ function clip8envokeOperation() {
                     break;
                 default:        throw "[clip8envokeOperation] Encountered invalid line direction (a)."; break;
             }
-            running = false;
         }
         else
             throw "Could not decode instruction X"+instr1;
@@ -145,7 +142,7 @@ function clip8envokeOperation() {
         tracesvgroot.appendChild(instr1);
         tracesvgroot.appendChild(sel1);
         if (debug) console.log("clip8envokeOperation: removed instr1, sel1", instr1, sel1);
-    }
+
     var erasetracetimer = setInterval( function() { eraseTrace(tracesvgroot) }, 60 );
     setTimeout ( function () { clearInterval(erasetracetimer) }, 10000 );   // stop erasor after some time
 }

--- a/spec/spec_DOMrefsheet.js
+++ b/spec/spec_DOMrefsheet.js
@@ -81,7 +81,8 @@ function addTest_invokeOperation(reftestElement) {
         expect(svgroot.id).toBe("");
         svgroot.setAttributeNS(null,"id", "clip8svgroot");
         expect(svgroot.id).toBe("clip8svgroot");
-        expect(clip8envokeOperation).not.toThrow();
+        expect(Clip8.envokeOperation).not.toThrow();
+        expect(Clip8.getPrimInstruction).toHaveBeenCalled();
         svgroot.removeAttribute("id", reftestElement.id);
         done();
     });
@@ -107,6 +108,7 @@ describe("Reference Sheet Tester", function(){
         jasmine.addMatchers(customMatchers);
         var oldroot = document.getElementById("clip8svgroot");
         if (oldroot) { oldroot.removeAttributeNS(null,"id"); }  // remove id from any leftover #clip8svgroot element
+        spyOn(Clip8,"getPrimInstruction").and.callThrough();
     });
 
     var  tests = document.getElementsByClassName("DOMreftest");

--- a/spec/spec_DOMrefsheet.js
+++ b/spec/spec_DOMrefsheet.js
@@ -83,8 +83,10 @@ function addTest_invokeOperation(reftestElement) {
         svgroot.setAttributeNS(null,"id", "clip8svgroot");
         expect(svgroot.id).toBe("clip8svgroot");
         expect(Clip8.envokeOperation).not.toThrow();
-        jasmine.clock().tick(1000);
+        jasmine.clock().tick(10000);
         expect(Clip8.executeOneOperation).toHaveBeenCalled();
+        expect(Clip8.executeOneOperation.calls.count()).toBeLessThan(20);
+        expect(Clip8.clearExecTimer).toHaveBeenCalled();
         svgroot.removeAttribute("id", reftestElement.id);
         jasmine.clock().uninstall();
         done();
@@ -112,6 +114,7 @@ describe("Reference Sheet Tester", function(){
         var oldroot = document.getElementById("clip8svgroot");
         if (oldroot) { oldroot.removeAttributeNS(null,"id"); }  // remove id from any leftover #clip8svgroot element
         spyOn(Clip8,"executeOneOperation").and.callThrough();
+        spyOn(Clip8,"clearExecTimer").and.callThrough();
     });
 
     var  tests = document.getElementsByClassName("DOMreftest");

--- a/spec/spec_DOMrefsheet.js
+++ b/spec/spec_DOMrefsheet.js
@@ -74,6 +74,7 @@ function addTest_invokeOperation(reftestElement) {
     test_domids.push(reftestElement.id);
 
     spec = it("["+reftestElement.id+"] EXECUTE the operation without error", function(done) {
+        jasmine.clock().install();
         var proc = getTestDOM(reftestElement);
         expect(proc.classList).toContain("testDOM");
         var svgroot = proc.firstElementChild;
@@ -82,8 +83,10 @@ function addTest_invokeOperation(reftestElement) {
         svgroot.setAttributeNS(null,"id", "clip8svgroot");
         expect(svgroot.id).toBe("clip8svgroot");
         expect(Clip8.envokeOperation).not.toThrow();
-        expect(Clip8.getPrimInstruction).toHaveBeenCalled();
+        jasmine.clock().tick(1000);
+        expect(Clip8.executeOneOperation).toHaveBeenCalled();
         svgroot.removeAttribute("id", reftestElement.id);
+        jasmine.clock().uninstall();
         done();
     });
     test_specids.push(spec.id);
@@ -108,7 +111,7 @@ describe("Reference Sheet Tester", function(){
         jasmine.addMatchers(customMatchers);
         var oldroot = document.getElementById("clip8svgroot");
         if (oldroot) { oldroot.removeAttributeNS(null,"id"); }  // remove id from any leftover #clip8svgroot element
-        spyOn(Clip8,"getPrimInstruction").and.callThrough();
+        spyOn(Clip8,"executeOneOperation").and.callThrough();
     });
 
     var  tests = document.getElementsByClassName("DOMreftest");


### PR DESCRIPTION
Create an object `Clip8`, turn the functions into methods. (Now we can spy on them via jasmine)

`envokeOperation` method initiated an interval timer to call `executeOneOperation` every xxx miliseconds. 
`executeOneOperation` calls `clearExecTimer` when finished; currently after the first run.
`Clip8.exectimer` will be used by `clearExecTimer` method to stop execution again.

Test now spies for `Clip8.exectimer` and `clearExecTimer` to have been called after 10000msecs. Also,  `Clip8.exectimer` should be called no more than 20 times.