### PR TITLE
Finalise absilute align: passes all tests.

### DIFF
--- a/js/clip8.js
+++ b/js/clip8.js
@@ -59,7 +59,7 @@ var Clip8 = {
 
     getInstrEls_asGroups: function (arearect, svgroot) {
         var debug = false;
-        if (debug) console.log("[getInstrEls_asGroups] arearect, svgroot", arearect, svgroot);
+        if (debug) console.log("[GETINSTRELS_ASGROUPS] arearect, svgroot", arearect, svgroot);
         arearect.setAttribute("fill", "#FFEE22");
         svgroot.appendChild(arearect);
         var s = svgretrieve_selectorFromRect(arearect, svgroot);
@@ -105,7 +105,7 @@ var Clip8 = {
         var arearect = svgdom_EndOfPathArea(Clip8.ip, epsilon);
         Clip8.blocklist = [];   // reset the blocklist; we are fetching a new instruction
         var instrNsel = Clip8.getInstrEls_asGroups(arearect, svgroot);
-        if (debug) console.log("[clip8envokeOperation] instrNsel: ", instrNsel);
+        if (debug) console.log("[clip8envokeOperation] instrNsel (1): ", instrNsel);
         var instr1 = instrNsel[0];
         var sel1 = instrNsel[1];
         Clip8.ip = instrNsel[2];
@@ -147,9 +147,9 @@ var Clip8 = {
             if (debug) console.log("clip8envokeOperation: angle direction", angledir);
             var arearect = svgdom_EndOfLineArea(theline, epsilon);
             var instrNsel = Clip8.getInstrEls_asGroups(arearect, svgroot);
+            if (debug) console.log("[clip8envokeOperation] instrNsel (2): ", instrNsel);
             var instr2 = instrNsel[0];
             var sel2 = instrNsel[1];
-            if (debug) console.log("[clip8envokeOperation] instr2, sel2:", instr2, sel2);
             switch (linedir) {
                 case 'UP':
                 case 'DOWN':

--- a/js/clip8.js
+++ b/js/clip8.js
@@ -150,6 +150,9 @@ var Clip8 = {
             if (debug) console.log("[clip8envokeOperation] instrNsel (2): ", instrNsel);
             var instr2 = instrNsel[0];
             var sel2 = instrNsel[1];
+            var snd_signature = clip8countTags(instr2, ["rect"]);
+            if (snd_signature.toString() === [1].toString() )
+                selectedelements1.push(instr2.firstChild); // Add the absolute rectangle to the selected set.
             switch (linedir) {
                 case 'UP':
                 case 'DOWN':
@@ -165,6 +168,11 @@ var Clip8 = {
                     break;
                 default:        throw "[clip8envokeOperation] Encountered invalid line direction (a)."; break;
             }
+            if (debug) console.log("clip8envokeOperation: remove instr2, sel2", instr2, sel2);
+            svgroot.removeChild(instr2);
+            svgroot.removeChild(sel2);
+            tracesvgroot.appendChild(instr2);
+            tracesvgroot.appendChild(sel2);
         }
         else
             throw "Could not decode instruction X"+instr1;
@@ -173,13 +181,6 @@ var Clip8 = {
         svgroot.removeChild(sel1);
         tracesvgroot.appendChild(instr1);
         tracesvgroot.appendChild(sel1);
-        /* FIXME: see fix above.
-        if (debug) console.log("clip8envokeOperation: remove instr2, sel2", instr2, sel2);
-        svgroot.removeChild(instr2);
-        svgroot.removeChild(sel2);
-        tracesvgroot.appendChild(instr2);
-        tracesvgroot.appendChild(sel2);
-        */
         if (terminate) Clip8.clearExecTimer();
     },
 


### PR DESCRIPTION
Fetch the secondary instruction elements, while avoiding double retrieval via a blocklist.
If there is a rectangle attached to the pivot line of an align instruction, treat it as a member of the selection set (hence, make the align absolute).