### PR TITLE
Refactor selectors handling and isolated selector test.

### DIFF
--- a/js/clip8.js
+++ b/js/clip8.js
@@ -101,8 +101,8 @@ var Clip8 = {
 
         // List of selected Elements based on primary selector
         var selection = [];
-        if (selectorelements.firstChild instanceof SVGRectElement) {
-            var s = Svgretrieve.selectorFromRect(selectorelements.firstChild, svgroot);
+        if (selectorelements[0] instanceof SVGRectElement) {
+            var s = Svgretrieve.selectorFromRect(selectorelements[0], svgroot);
             if (debug) console.log("[executeOneOperation] selector from rect in selectorelements:", s);
             var hitlist = svgroot.getEnclosureList(s, svgroot);
             for ( var i = 0; i < hitlist.length; i++ )

--- a/js/clip8.js
+++ b/js/clip8.js
@@ -32,7 +32,7 @@ var Clip8 = {
         var initialflow = null;
 
         for ( var i = 0; i < circles.length; i++ ) {
-            var r = Svgdom.CentreArea(circles[i], epsilon);
+            var r = Svgdom.newRectElement_fromSVGRect(Svgdom.getCentreArea(circles[i], epsilon));
             r.setAttribute("fill", "#ffff33");
             centres.appendChild(r);
         }
@@ -57,11 +57,7 @@ var Clip8 = {
     getInstrEls_asGroups: function (arearect, svgroot) {
         var debug = false;
         if (debug) console.log("[GETINSTRELS_ASGROUPS] arearect, svgroot:", arearect, svgroot);
-        arearect.setAttribute("fill", "#FFEE22");
-        svgroot.appendChild(arearect);
-        var s = Svgretrieve.selectorFromRect(arearect, svgroot);
-        svgroot.removeChild(arearect);
-        var hitlist = svgroot.getIntersectionList(s, svgroot);
+        var hitlist = svgroot.getIntersectionList(arearect, svgroot);
         if (debug)  console.log("[getInstrEls_asGroups] hitlist:", hitlist);
         if (hitlist.length == 0) throw "[clip8getInstrEls_asGroups] empty hitlist.";
         var sel = Svgdom.addGroup(svgroot);
@@ -124,7 +120,7 @@ var Clip8 = {
         if (debug) console.log("[EXECUTEONEOPERATION] Clip8.ip, svgroot, tracesvgroot:", Clip8.ip, svgroot, tracesvgroot);
         if (Clip8.ip.tagName != "path") throw "[executeOneOperation] ip element is not a path.";
 
-        var arearect = Svgdom.EndOfPathArea(Clip8.ip, epsilon);
+        var arearect = Svgdom.getEndOfPathArea(Clip8.ip, epsilon);
         Clip8.blocklist = [];   // reset the blocklist; we are fetching a new instruction
         var instrNsel = Clip8.getInstrEls_asGroups(arearect, svgroot);
         if (debug) console.log("[executeOneOperation] instrNsel (A) [0, 1, 2]:", instrNsel[0].childNodes, instrNsel[1].childNodes, instrNsel[2]);
@@ -155,7 +151,7 @@ var Clip8 = {
             var thepoly = instr1.getElementsByTagName("polyline")[0];
             var angledir = clip8directionOfPolyAngle(thepoly, epsilon, minlen);
             if (debug) console.log("[executeOneOperation] angle direction:", angledir);
-            var arearect = Svgdom.EndOfLineArea(theline, epsilon);
+            var arearect = Svgdom.getEndOfLineArea(theline, epsilon);
             var instrNsel = Clip8.getInstrEls_asGroups(arearect, svgroot);
             if (debug) console.log("[executeOneOperation] instrNsel(B) [0, 1]:", instrNsel[0].childNodes, instrNsel[1].childNodes);
             var instr2 = instrNsel[0];

--- a/js/svgdom.js
+++ b/js/svgdom.js
@@ -13,11 +13,11 @@ var Svgdom = {
         return g;
     },
 
-    newRect: function (x,y,w,h) {
+    newRectElement: function (x,y,w,h) {
+        /** Create an SVG DOM rect element */
         var debug = false;
-        if (debug) console.log("Svgdom.newRect:",x,y,w,h);
+        if (debug) console.log("[newRectElement] x, y, w, h:", x, y, w, h);
         var r = document.createElementNS(Svgdom.SVGNS, "rect");
-        //var r = document.createElement("XXX", "rect");
         r.setAttribute("x",x);
         r.setAttribute("y",y);
         r.setAttribute("width",w);
@@ -25,27 +25,49 @@ var Svgdom = {
         return r;
     },
 
+    newRectElement_fromSVGRect (r) {
+        return Svgdom.newRectElement(r.x, r.y, r.width, r.height);
+    },
+
+    epsilonRectAt: function (x, y, epsilon, somesvgelement) {
+        var svgroot;
+        var debug = false;
+        if (debug) console.log("[epsilonRectAt] x, y, epsilon, somesvgelement:", x, y, epsilon, somesvgelement);
+        if          (somesvgelement instanceof SVGSVGElement)   svgroot = somesvgelement;
+        else if     (somesvgelement instanceof SVGElement)      svgroot = somesvgelement.ownerSVGElement;
+        else {
+            if (debug) console.log("[epsilonRectAt] invalid svg elment:", somesvgelement);
+            throw "[epsilonRectAt] Expected an instance of SVGSVGElement or SVGElement.";
+        }
+        var r = svgroot.createSVGRect();
+        r.x = x-epsilon;
+        r.y = y-epsilon
+        r.width = epsilon*2;
+        r.height = epsilon*2;
+        return r;
+    },
+
     addRect: function (parentel,x,y,w,h) {
-        var r = Svgdom.newRect(x,y,w,h);
+        var r = Svgdom.newRectElement(x,y,w,h);
         parentel.appendChild(r);
         return r;
     },
 
-    CentreArea: function (circle, epsilon) {
+    getCentreArea: function (circle, epsilon) {
         /** Returns an SVG rect `r` around the centre of circle.
         *   `width == 2*epsilon`.
         */
-        return Svgdom.newRect(circle.cx.baseVal.value-epsilon, circle.cy.baseVal.value-epsilon, epsilon*2, epsilon*2);
+        return Svgdom.epsilonRectAt(circle.cx.baseVal.value, circle.cy.baseVal.value, epsilon, circle);
     },
 
-    EndOfLineArea: function (line, epsilon) {
+    getEndOfLineArea: function (line, epsilon) {
         /** Returns an SVG rect `r` around the endpoint of `line`.
         *   `width == 2*epsilon`.
         */
-        return Svgdom.newRect(line.x2.baseVal.value-epsilon, line.y2.baseVal.value-epsilon, epsilon*2, epsilon*2);
+        return Svgdom.epsilonRectAt(line.x2.baseVal.value, line.y2.baseVal.value, epsilon, line);
     },
 
-    EndOfPathArea: function (path, epsilon) {
+    getEndOfPathArea: function (path, epsilon) {
         /** Returns an SVG rect `r` around the endpoint of a path.
         *   `width == 2*epsilon`.
         */
@@ -82,6 +104,6 @@ var Svgdom = {
             if (debug) console.log("Svgdom.EndOfPathArea B: endx, endy", endx, endy);
         }
         else throw ("Svgdom.EndOfPathArea: Need exactly one curve segment. "+pathdata);
-        return Svgdom.newRect(endx-epsilon, endy-epsilon, epsilon*2, epsilon*2);
+        return Svgdom.epsilonRectAt(endx, endy, epsilon, path);
     }
 }

--- a/spec/spec_DOMrefsheet.js
+++ b/spec/spec_DOMrefsheet.js
@@ -136,8 +136,10 @@ function addTest_selectionset(reftestElement, p0x, p0y, color) {
         expect(proc.classList).toContain("testDOM");
         var svgroot = proc.firstElementChild;
         expect(svgroot).toBeElement();
-        var arearect = Svgdom.newRect(p0x-epsilon, p0y-epsilon, epsilon*2, epsilon*2);
-        var selectionset = Clip8.handleSelectorAt(arearect, svgroot);
+        var arearect = Svgdom.epsilonRectAt(p0x, p0y, epsilon, svgroot);
+        Clip8.blocklist = [];   // reset the blocklist; we are fetching a new instruction
+        var sel = svgroot.getIntersectionList(arearect, svgroot);;
+        var selectionset = Clip8.getSelectedElements(sel, svgroot);
         for (var i = 0; i < selectionset.length; i++) {
             console.log("[addTest_selectionset] selectionset[i]:", selectionset[i]);
             if (selectionset[i] instanceof SVGElement)

--- a/spec/spec_DOMrefsheet.js
+++ b/spec/spec_DOMrefsheet.js
@@ -2,6 +2,7 @@
 var CLIP8_RUNNINGTIME = 500
 
 var customMatchers = {
+
 toBeElement:
     function (util, customEqualityTesters) {
         return {
@@ -23,7 +24,38 @@ toMatchReference:
                 var cmpB = expected.outerHTML.replace(/\s+/gm, " ")
                 result.pass = cmpA==cmpB;
                 if (debug) console.log("tests: ", cmpA, "==", cmpB, result.pass);
-                result.message = "Expected " + actual + " to equal " + expected + ".";
+                result.message = "Expected " + cmpA + " to equal " + cmpB + ".";
+                return result;
+            }
+        };
+    },
+
+_toStringSortAttrs: function (el) {
+    var result = "";
+    for (var i = 0; i < el.childNodes.length; i++) {
+        if ((el.childNodes[i] instanceof SVGElement) || (el.childNodes[i] instanceof HTMLElement)) {
+            result += el.childNodes[i].tagName + ": ";
+            var attribsAsStrings = [];
+            for (var j = 0; j < el.childNodes[i].attributes.length ; j++)
+                attribsAsStrings.push( el.childNodes[i].attributes[j].name + "=" + el.childNodes[i].attributes[j].value );
+            attribsAsStrings.sort();
+            result += attribsAsStrings.toString() + "; ";
+        }
+    }
+    return result;
+},
+
+attributesOfChildrenToMatch:
+    function (util, customEqualityTesters) {
+        return {
+            compare: function(actual, expected) {
+                var result = {};
+                var debug = false;
+                var actualCmp = customMatchers._toStringSortAttrs(actual);
+                var expectedCmp = customMatchers._toStringSortAttrs(expected);
+                result.pass = actualCmp==expectedCmp;
+                if (debug) console.log("tests: ", actualCmp, "==", expectedCmp, result.pass);
+                result.message = "Expected " + actualCmp + " to equal " + expectedCmp + ".";
                 return result;
             }
         };
@@ -125,7 +157,13 @@ function addTest_selectionset(reftestElement, p0x, p0y, color) {
 
     spec = it("["+reftestElement.id+"] PRE and TEST should be equal",
         function(done) {
-        GenericTestFns.matchPre(reftestElement);
+        var pre = getPrecondition(reftestElement);
+        var proc = getTestDOM(reftestElement);
+        expect(pre.classList).toContain("pre-reference");
+        expect(proc.classList).toContain("testDOM");
+        expect(proc.firstElementChild).toBeElement();
+        expect(pre.firstElementChild).toBeElement();
+        expect(proc.firstElementChild).attributesOfChildrenToMatch(pre.firstElementChild);
         done();
     });
     test_specids.push(spec.id);
@@ -151,7 +189,13 @@ function addTest_selectionset(reftestElement, p0x, p0y, color) {
     test_domids.push(reftestElement.id);
 
     spec = it("["+reftestElement.id+"] TEST and POST should be equal", function(done) {
-        GenericTestFns.matchPost(reftestElement);
+        var proc = getTestDOM(reftestElement);
+        var post = getPostcondition(reftestElement);
+        expect(proc.classList).toContain("testDOM");
+        expect(post.classList).toContain("post-reference");
+        expect(proc.firstElementChild).toBeElement();
+        expect(post.firstElementChild).toBeElement();
+        expect(proc.firstElementChild).attributesOfChildrenToMatch(post.firstElementChild);
         done();
     });
     test_specids.push(spec.id);


### PR DESCRIPTION
`handleSelectorsAt` -> `getSelectedElements`
gets a list of Elements rather than an area, as was the case for the stub.

This allows to keep `getInstrEls_asGroups` largely untouched: Only change here is to work with a SVGRect  as a parameter, but avoid adding a rect element to the DOM. 

The Selector test compares direct children, only. In exchange, it sorts attributes before stringifying and comparing. Color is added dynamically in this test type -- which disrupted the order in attributes.
(cf. #39)