### PR TITLE
Separates selector element retrieval from object selection.

### DIFF
--- a/bin/Sections.py
+++ b/bin/Sections.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 
-refsheet_version = "0.0.3"
+refsheet_version = "0.0.4"
 refsheet_description = "encompasses a usable (incomplete) language repertoire."
 
 sections = [
@@ -15,7 +15,7 @@ sections = [
 
 expected_to_fail = [
     "alternative-join-combo", "alternative-join-combo2", "alternative-join-combo3", "alternative-join-combo4", "alternative-join-combo5",
-    "enclose2", "intersect1", "intersect2", "indirect1", "indirect2", "indirect3",
+    "intersect1", "intersect2", "indirect1", "indirect2", "indirect3",
     "move-bysize-down", "move-bysize-down2",
     "moveto-lowerleft", "moveto-lowerleft2", "moveto-upperleft",
     "clone1", "cut-vertical", "delete1", "delete2",

--- a/js/clip8.js
+++ b/js/clip8.js
@@ -130,40 +130,40 @@ var Clip8 = {
         var POLYLINEidx = 1;
         var CIRCLEidx = 2;
         var RECTidx = 3;
-        var icsA = Clip8.retrieveISCElements(p0area, svgroot, TAGS, TAGS);
-        if (debug) console.log("[executeOneOperation] icsA [0, 1, 2]:", icsA[0], icsA[1], icsA[2]);
-        var I = icsA[0];
-        var S = icsA[1];
-        Clip8.ip = icsA[2];
-        if (debug) console.log("[executeOneOperation] S[RECTidx]:", S[RECTidx]);
-        var selectedelements1 = Clip8.getSelectedElements(S[RECTidx], svgroot);
+        var ICS0 = Clip8.retrieveISCElements(p0area, svgroot, TAGS, TAGS);
+        if (debug) console.log("[executeOneOperation] ICS0 [0, 1, 2]:", ICS0[0], ICS0[1], ICS0[2]);
+        var I0 = ICS0[0];
+        var S0 = ICS0[1];
+        Clip8.ip = ICS0[2];
+        if (debug) console.log("[executeOneOperation] S0[RECTidx]:", S0[RECTidx]);
+        var selectedelements1 = Clip8.getSelectedElements(S0[RECTidx], svgroot);
         if (debug) console.log("[executeOneOperation] selectedelements1:", selectedelements1);
 
-        if ( I[CIRCLEidx].length == 2 ) {
+        if ( I0[CIRCLEidx].length == 2 ) {
             if (debug) console.log("[executeOneOperation] two circles.");
-            if (I[CIRCLEidx][0].tagName == "circle" &&
-                I[CIRCLEidx][1].tagName == "circle") {
+            if (I0[CIRCLEidx][0].tagName == "circle" &&
+                I0[CIRCLEidx][1].tagName == "circle") {
                 if (debug) console.log("[executeOneOperation] TERMINAL.");
                 terminate = true;
             }
             else throw "Could not decode instruction A"+instr1;
         }
-        else if ( I[LINEidx].length == 1 && I[POLYLINEidx].length == 1 ) {
+        else if ( I0[LINEidx].length == 1 && I0[POLYLINEidx].length == 1 ) {
             // ALIGN
             if (debug) console.log("[executeOneOperation] 1 line, 1 polyline.");
-            var theline = I[LINEidx][0];
+            var theline = I0[LINEidx][0];
             var linedir = Clip8decode.directionOfSVGLine(theline, epsilon, minlen);
             if (debug) console.log("[executeOneOperation] direction:", linedir);
-            var thepoly = I[POLYLINEidx][0];
+            var thepoly = I0[POLYLINEidx][0];
             var angledir = Clip8decode.directionOfPolyAngle(thepoly, epsilon, minlen);
             if (debug) console.log("[executeOneOperation] angle direction:", angledir);
             var arearect = Svgdom.epsilonRectAt(Svgdom.getEndOfLinePoint(theline), epsilon, svgroot);
-            var icsB = Clip8.retrieveISCElements(arearect, svgroot, TAGS, TAGS);
-            if (debug) console.log("[executeOneOperation] icsB [0, 1, 2]:", icsB[0], icsB[1], icsB[2]);
-            var I2 = icsB[0];
-            var S2 = icsB[1];
-            if (I2[RECTidx].length == 1 )
-                selectedelements1.push(I2[RECTidx][0]); // Add the absolute rectangle to the selected set.
+            var ICS1 = Clip8.retrieveISCElements(arearect, svgroot, TAGS, TAGS);
+            if (debug) console.log("[executeOneOperation] ICS1 [0, 1, 2]:", ICS1[0], ICS1[1], ICS1[2]);
+            var I1 = ICS1[0];
+            var S1 = ICS1[1];
+            if (I1[RECTidx].length == 1 )
+                selectedelements1.push(I1[RECTidx][0]); // Add the absolute rectangle to the selected set.
             switch (linedir) {
                 case 'UP':
                 case 'DOWN':
@@ -180,10 +180,10 @@ var Clip8 = {
                 default:        throw "[executeOneOperation] Encountered invalid line direction (a)."; break;
             }
         }
-        else if ( I[LINEidx].length == 1 && I[POLYLINEidx].length == 0 ) {
+        else if ( I0[LINEidx].length == 1 && I0[POLYLINEidx].length == 0 ) {
             // MOVE-REL, CUT
             if (debug) console.log("[executeOneOperation] 1 line.");
-            var theline = I[LINEidx][0];
+            var theline = I0[LINEidx][0];
             if (theline.getAttribute("stroke-dasharray")) {
                 // CUT
                 var linedir = Clip8decode.directionOfSVGLine(theline, epsilon, minlen);

--- a/js/clip8.js
+++ b/js/clip8.js
@@ -5,6 +5,13 @@ var epsilon = 0.5;  // maximal difference for two coordinates to be considered e
 var minlen = 1.5;     // minimal size of a graphics element to be "meaningful"
 
 var Clip8 = {
+    // Constants
+    TAGS: ["line", "polyline", "circle", "rect"],
+    LINETAG: 0,
+    POLYLINETAG: 1,
+    CIRCLETAG: 2,
+    RECTTAG: 3,
+    // Variables
     exectimer: null,
     ip: null,       // instruction pointer
     blocklist: [],  // list of elements already retrieved during current instruction cycle.
@@ -124,46 +131,40 @@ var Clip8 = {
         var p0 = Svgdom.getEndOfPathPoint(Clip8.ip);
         var p0area = Svgdom.epsilonRectAt(p0, epsilon, svgroot);
         Clip8.blocklist = [];   // reset the blocklist; we are fetching a new instruction
-        // Some constants:
-        var TAGS = ["line", "polyline", "circle", "rect"];
-        var LINEidx = 0;
-        var POLYLINEidx = 1;
-        var CIRCLEidx = 2;
-        var RECTidx = 3;
-        var ICS0 = Clip8.retrieveISCElements(p0area, svgroot, TAGS, TAGS);
+        var ICS0 = Clip8.retrieveISCElements(p0area, svgroot, Clip8.TAGS, Clip8.TAGS);
         if (debug) console.log("[executeOneOperation] ICS0 [0, 1, 2]:", ICS0[0], ICS0[1], ICS0[2]);
         var I0 = ICS0[0];
         var S0 = ICS0[1];
         Clip8.ip = ICS0[2];
-        if (debug) console.log("[executeOneOperation] S0[RECTidx]:", S0[RECTidx]);
-        var selectedelements1 = Clip8.getSelectedElements(S0[RECTidx], svgroot);
+        if (debug) console.log("[executeOneOperation] S0[Clip8.RECTTAG]:", S0[Clip8.RECTTAG]);
+        var selectedelements1 = Clip8.getSelectedElements(S0[Clip8.RECTTAG], svgroot);
         if (debug) console.log("[executeOneOperation] selectedelements1:", selectedelements1);
 
-        if ( I0[CIRCLEidx].length == 2 ) {
+        if ( I0[Clip8.CIRCLETAG].length == 2 ) {
             if (debug) console.log("[executeOneOperation] two circles.");
-            if (I0[CIRCLEidx][0].tagName == "circle" &&
-                I0[CIRCLEidx][1].tagName == "circle") {
+            if (I0[Clip8.CIRCLETAG][0].tagName == "circle" &&
+                I0[Clip8.CIRCLETAG][1].tagName == "circle") {
                 if (debug) console.log("[executeOneOperation] TERMINAL.");
                 terminate = true;
             }
             else throw "Could not decode instruction A"+instr1;
         }
-        else if ( I0[LINEidx].length == 1 && I0[POLYLINEidx].length == 1 ) {
+        else if ( I0[Clip8.LINETAG].length == 1 && I0[Clip8.POLYLINETAG].length == 1 ) {
             // ALIGN
             if (debug) console.log("[executeOneOperation] 1 line, 1 polyline.");
-            var theline = I0[LINEidx][0];
+            var theline = I0[Clip8.LINETAG][0];
             var linedir = Clip8decode.directionOfSVGLine(theline, epsilon, minlen);
             if (debug) console.log("[executeOneOperation] direction:", linedir);
-            var thepoly = I0[POLYLINEidx][0];
+            var thepoly = I0[Clip8.POLYLINETAG][0];
             var angledir = Clip8decode.directionOfPolyAngle(thepoly, epsilon, minlen);
             if (debug) console.log("[executeOneOperation] angle direction:", angledir);
             var arearect = Svgdom.epsilonRectAt(Svgdom.getEndOfLinePoint(theline), epsilon, svgroot);
-            var ICS1 = Clip8.retrieveISCElements(arearect, svgroot, TAGS, TAGS);
+            var ICS1 = Clip8.retrieveISCElements(arearect, svgroot, Clip8.TAGS, Clip8.TAGS);
             if (debug) console.log("[executeOneOperation] ICS1 [0, 1, 2]:", ICS1[0], ICS1[1], ICS1[2]);
             var I1 = ICS1[0];
             var S1 = ICS1[1];
-            if (I1[RECTidx].length == 1 )
-                selectedelements1.push(I1[RECTidx][0]); // Add the absolute rectangle to the selected set.
+            if (I1[Clip8.RECTTAG].length == 1 )
+                selectedelements1.push(I1[Clip8.RECTTAG][0]); // Add the absolute rectangle to the selected set.
             switch (linedir) {
                 case 'UP':
                 case 'DOWN':
@@ -180,10 +181,10 @@ var Clip8 = {
                 default:        throw "[executeOneOperation] Encountered invalid line direction (a)."; break;
             }
         }
-        else if ( I0[LINEidx].length == 1 && I0[POLYLINEidx].length == 0 ) {
+        else if ( I0[Clip8.LINETAG].length == 1 && I0[Clip8.POLYLINETAG].length == 0 ) {
             // MOVE-REL, CUT
             if (debug) console.log("[executeOneOperation] 1 line.");
-            var theline = I0[LINEidx][0];
+            var theline = I0[Clip8.LINETAG][0];
             if (theline.getAttribute("stroke-dasharray")) {
                 // CUT
                 var linedir = Clip8decode.directionOfSVGLine(theline, epsilon, minlen);

--- a/js/clip8.js
+++ b/js/clip8.js
@@ -109,7 +109,7 @@ var Clip8 = {
             var epsilon = 0.01;
             var arearect = Svgdom.epsilonRectAt(Svgdom.getEndOfLinePoint(S[Clip8.LINETAG][0]), epsilon, svgroot);
             var isc = Clip8.retrieveISCElements(arearect, svgroot, Clip8.TAGS, Clip8.TAGS);
-            if (debug) console.log("[retrieveCoreSelector] local ics [0, 1, 2]:", isc[0], isc[1], isc[2]);
+            if (debug) console.log("[retrieveCoreSelector] local isc [0, 1, 2]:", isc[0], isc[1], isc[2]);
             coreS = isc[1];
         }
         else {
@@ -157,11 +157,11 @@ var Clip8 = {
         var p0 = Svgdom.getEndOfPathPoint(Clip8.ip);
         var p0area = Svgdom.epsilonRectAt(p0, epsilon, svgroot);
         Clip8.blocklist = [];   // reset the blocklist; we are fetching a new instruction
-        var ICS0 = Clip8.retrieveISCElements(p0area, svgroot, Clip8.TAGS, Clip8.TAGS);
-        if (debug) console.log("[executeOneOperation] ICS0 [0, 1, 2]:", ICS0[0], ICS0[1], ICS0[2]);
-        var I0 = ICS0[0];
-        var S0 = ICS0[1];
-        Clip8.ip = ICS0[2];
+        var ISC0 = Clip8.retrieveISCElements(p0area, svgroot, Clip8.TAGS, Clip8.TAGS);
+        if (debug) console.log("[executeOneOperation] ISC0 [0, 1, 2]:", ISC0[0], ISC0[1], ISC0[2]);
+        var I0 = ISC0[0];
+        var S0 = ISC0[1];
+        Clip8.ip = ISC0[2];
         if (debug) console.log("[executeOneOperation] S0:", S0);
         var retrselector = Clip8.retrieveCoreSelector(S0, svgroot)
         var selectortype = retrselector[0];
@@ -193,10 +193,10 @@ var Clip8 = {
             var angledir = Clip8decode.directionOfPolyAngle(thepoly, epsilon, minlen);
             if (debug) console.log("[executeOneOperation] angle direction:", angledir);
             var arearect = Svgdom.epsilonRectAt(Svgdom.getEndOfLinePoint(theline), epsilon, svgroot);
-            var ICS1 = Clip8.retrieveISCElements(arearect, svgroot, Clip8.TAGS, Clip8.TAGS);
-            if (debug) console.log("[executeOneOperation] ICS1 [0, 1, 2]:", ICS1[0], ICS1[1], ICS1[2]);
-            var I1 = ICS1[0];
-            var S1 = ICS1[1];
+            var ISC1 = Clip8.retrieveISCElements(arearect, svgroot, Clip8.TAGS, Clip8.TAGS);
+            if (debug) console.log("[executeOneOperation] ISC1 [0, 1, 2]:", ISC1[0], ISC1[1], ISC1[2]);
+            var I1 = ISC1[0];
+            var S1 = ISC1[1];
             if (I1[Clip8.RECTTAG].length == 1 )
                 selectedelements1.push(I1[Clip8.RECTTAG][0]); // Add the absolute rectangle to the selected set.
             switch (linedir) {

--- a/js/clip8.js
+++ b/js/clip8.js
@@ -98,20 +98,21 @@ var Clip8 = {
         return [I, S, nextIP];
     },
 
-    getSelectedElements: function(selectorelements, svgroot) {
-        /** Retreve the set of selected objects as defined by a given selector.
-         *  `selectorelements` is the list of SVG DOM elments being the selector
-         *  part of an instruction. These elements graphically depict the selector.
-         *  Return value is a list of SVG DOM elements that are selected by the given selector. */
+    selectedElementSet: function (selectorcore, svgroot) {
+        /** Determine the set of selected elements based on given selector core.
+         *  `selectorcore` is the list of SVG DOM elments being the core selector
+         *  (excluding connectors). Typically these elements graphically depict an area.
+         *  Return value is a list of SVG DOM elements that are selected by the given selector. 
+         */
 
         var debug = false;
-        if (debug) console.log("[GETSELECTEDELEMENTS] arearect:", selectorelements, svgroot);
+        if (debug) console.log("[SELECTEDELEMENTSET] arearect:", selectorcore, svgroot);
 
         // List of selected Elements based on primary selector
         var selection = [];
-        if (selectorelements[0] instanceof SVGRectElement) {
-            var s = Svgretrieve.selectorFromRect(selectorelements[0], svgroot);
-            if (debug) console.log("[executeOneOperation] selector from rect in selectorelements:", s);
+        if (selectorcore[0] instanceof SVGRectElement) {
+            var s = Svgretrieve.selectorFromRect(selectorcore[0], svgroot);
+            if (debug) console.log("[selectedElementSet] selector from rect in selectorcore:", s);
             var hitlist = svgroot.getEnclosureList(s, svgroot);
             for ( var i = 0; i < hitlist.length; i++ )
                 if ( hitlist[i].tagName == "rect" &&
@@ -137,7 +138,7 @@ var Clip8 = {
         var S0 = ICS0[1];
         Clip8.ip = ICS0[2];
         if (debug) console.log("[executeOneOperation] S0[Clip8.RECTTAG]:", S0[Clip8.RECTTAG]);
-        var selectedelements1 = Clip8.getSelectedElements(S0[Clip8.RECTTAG], svgroot);
+        var selectedelements1 = Clip8.selectedElementSet(S0[Clip8.RECTTAG], svgroot);
         if (debug) console.log("[executeOneOperation] selectedelements1:", selectedelements1);
 
         if ( I0[Clip8.CIRCLETAG].length == 2 ) {

--- a/spec/spec_DOMrefsheet.js
+++ b/spec/spec_DOMrefsheet.js
@@ -179,8 +179,15 @@ function addTest_selectionset(reftestElement, p0x, p0y, color) {
         p0.y = p0y;
         var arearect = Svgdom.epsilonRectAt(p0, epsilon, svgroot);
         Clip8.blocklist = [];   // reset the blocklist; we are fetching a new instruction
-        var sel = svgroot.getIntersectionList(arearect, svgroot);;
-        var selectionset = Clip8.selectedElementSet(sel, svgroot);
+        var sel = svgroot.getIntersectionList(arearect, svgroot);
+        var S = []
+        for ( var i = 0; i < Clip8.TAGS.length; i++ ) S.push([]);
+        for ( var i = 0; i < sel.length; i++ )
+            S = Clip8decode.pushByTagname(sel[i], Clip8.TAGS, S);
+        var retrselector = Clip8.retrieveCoreSelector(S, svgroot)
+        var selectortype = retrselector[0];
+        var coreselector = retrselector[1];
+        var selectionset = Clip8.selectedElementSet(coreselector, svgroot);
         for (var i = 0; i < selectionset.length; i++) {
             console.log("[addTest_selectionset] selectionset[i]:", selectionset[i]);
             if (selectionset[i] instanceof SVGElement)

--- a/spec/spec_DOMrefsheet.js
+++ b/spec/spec_DOMrefsheet.js
@@ -180,7 +180,7 @@ function addTest_selectionset(reftestElement, p0x, p0y, color) {
         var arearect = Svgdom.epsilonRectAt(p0, epsilon, svgroot);
         Clip8.blocklist = [];   // reset the blocklist; we are fetching a new instruction
         var sel = svgroot.getIntersectionList(arearect, svgroot);;
-        var selectionset = Clip8.getSelectedElements(sel, svgroot);
+        var selectionset = Clip8.selectedElementSet(sel, svgroot);
         for (var i = 0; i < selectionset.length; i++) {
             console.log("[addTest_selectionset] selectionset[i]:", selectionset[i]);
             if (selectionset[i] instanceof SVGElement)

--- a/tests/appendix.html
+++ b/tests/appendix.html
@@ -1737,7 +1737,7 @@
 
 
 <footer>
-<p><b>Version 0.0.3</b></p>
+<p><b>Version 0.0.4</b></p>
 </footer>
 
 <script src="../spec/spec_DOMrefsheet.js"></script>

--- a/tests/failing.html
+++ b/tests/failing.html
@@ -592,47 +592,6 @@ Thank you for your contribution!
 <h3>1.2&nbsp;&nbsp;<a href="test_selectors_genfromSVG.html">Selectors</a></h3>
 
 <!-- NOTE: The first three items in class list define the test. Handle with care! -->
-<p class="DOMreftest selectionset 4,4 #9E005D" id="enclose2">
-<span class="pre-reference">
-<svg viewbox="0 0 64 64" width="64" height="64">
-<rect height="20" width="28" x="28" y="12" /><rect height="16" width="11" x="45" y="36" /><rect height="40" width="16" x="8" y="12" /><rect fill="none" height="56" stroke="#E8ACAC" stroke-dasharray="1,2" stroke-miterlimit="10" width="40" x="20" y="4" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="1,1" stroke-miterlimit="10" x1="4" x2="20" y1="4" y2="60" /><g>
-			<g>
-				<line fill="none" stroke="#FFFFFF" stroke-miterlimit="10" x1="12" x2="9.108887" y1="2" y2="2.722656" />
-				<g>
-					<polygon fill="#FFFFFF" points="10.629883,0.595215 9.395508,2.650879 11.452148,3.884277 10.055664,4.233398 8,3        9.233398,0.944336      " />
-				</g>
-			</g>
-		</g>
-</svg>
-</span>
-&nbsp;==&gt;&nbsp;
-<span class="post-reference">
-<svg viewbox="0 0 64 64" width="64" height="64">
-<rect fill="#9E005D" height="20" width="28" x="28" y="12" /><rect fill="#9E005D" height="16" width="11" x="45" y="36" /><rect height="40" width="16" x="8" y="12" /><rect fill="none" height="56" stroke="#E8ACAC" stroke-dasharray="1,2" stroke-miterlimit="10" width="40" x="20" y="4" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="1,1" stroke-miterlimit="10" x1="4" x2="20" y1="4" y2="60" /><g>
-			<g>
-				<line fill="none" stroke="#FFFFFF" stroke-miterlimit="10" x1="12" x2="9.108887" y1="2" y2="2.722656" />
-				<g>
-					<polygon fill="#FFFFFF" points="10.629883,0.595215 9.395508,2.650879 11.452148,3.884277 10.055664,4.233398 8,3        9.233398,0.944336      " />
-				</g>
-			</g>
-		</g>
-</svg>
-</span>
-&nbsp;:&nbsp;&nbsp;&nbsp;
-<span class="testDOM">
-<svg viewbox="0 0 64 64" width="64" height="64">
-<rect height="20" width="28" x="28" y="12" /><rect height="16" width="11" x="45" y="36" /><rect height="40" width="16" x="8" y="12" /><rect fill="none" height="56" stroke="#E8ACAC" stroke-dasharray="1,2" stroke-miterlimit="10" width="40" x="20" y="4" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="1,1" stroke-miterlimit="10" x1="4" x2="20" y1="4" y2="60" /><g>
-			<g>
-				<line fill="none" stroke="#FFFFFF" stroke-miterlimit="10" x1="12" x2="9.108887" y1="2" y2="2.722656" />
-				<g>
-					<polygon fill="#FFFFFF" points="10.629883,0.595215 9.395508,2.650879 11.452148,3.884277 10.055664,4.233398 8,3        9.233398,0.944336      " />
-				</g>
-			</g>
-		</g>
-</svg>
-</span>
-</p>
-<!-- NOTE: The first three items in class list define the test. Handle with care! -->
 <p class="DOMreftest selectionset 4,4 #9E005D" id="intersect1">
 <span class="pre-reference">
 <svg viewbox="0 0 64 64" width="64" height="64">
@@ -1419,7 +1378,7 @@ Thank you for your contribution!
 
 
 <footer>
-<p><b>Version 0.0.3</b></p>
+<p><b>Version 0.0.4</b></p>
 </footer>
 
 <script src="../spec/spec_DOMrefsheet.js"></script>

--- a/tests/index.html
+++ b/tests/index.html
@@ -55,7 +55,7 @@ See <a href="https://github.com/broesamle/clip_8/">project documentation at gith
 
 <footer>
 <p>
-<b>Version 0.0.3</b> encompasses a usable (incomplete) language repertoire.<br>
+<b>Version 0.0.4</b> encompasses a usable (incomplete) language repertoire.<br>
 <p>
 © 2016, Martin Brösamle.<br>
 All rights reserved.

--- a/tests/passing.html
+++ b/tests/passing.html
@@ -159,6 +159,47 @@ Thank you for your contribution!
 </svg>
 </span>
 </p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest selectionset 4,4 #9E005D" id="enclose2">
+<span class="pre-reference">
+<svg viewbox="0 0 64 64" width="64" height="64">
+<rect height="20" width="28" x="28" y="12" /><rect height="16" width="11" x="45" y="36" /><rect height="40" width="16" x="8" y="12" /><rect fill="none" height="56" stroke="#E8ACAC" stroke-dasharray="1,2" stroke-miterlimit="10" width="40" x="20" y="4" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="1,1" stroke-miterlimit="10" x1="4" x2="20" y1="4" y2="60" /><g>
+			<g>
+				<line fill="none" stroke="#FFFFFF" stroke-miterlimit="10" x1="12" x2="9.108887" y1="2" y2="2.722656" />
+				<g>
+					<polygon fill="#FFFFFF" points="10.629883,0.595215 9.395508,2.650879 11.452148,3.884277 10.055664,4.233398 8,3        9.233398,0.944336      " />
+				</g>
+			</g>
+		</g>
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="0 0 64 64" width="64" height="64">
+<rect fill="#9E005D" height="20" width="28" x="28" y="12" /><rect fill="#9E005D" height="16" width="11" x="45" y="36" /><rect height="40" width="16" x="8" y="12" /><rect fill="none" height="56" stroke="#E8ACAC" stroke-dasharray="1,2" stroke-miterlimit="10" width="40" x="20" y="4" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="1,1" stroke-miterlimit="10" x1="4" x2="20" y1="4" y2="60" /><g>
+			<g>
+				<line fill="none" stroke="#FFFFFF" stroke-miterlimit="10" x1="12" x2="9.108887" y1="2" y2="2.722656" />
+				<g>
+					<polygon fill="#FFFFFF" points="10.629883,0.595215 9.395508,2.650879 11.452148,3.884277 10.055664,4.233398 8,3        9.233398,0.944336      " />
+				</g>
+			</g>
+		</g>
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="0 0 64 64" width="64" height="64">
+<rect height="20" width="28" x="28" y="12" /><rect height="16" width="11" x="45" y="36" /><rect height="40" width="16" x="8" y="12" /><rect fill="none" height="56" stroke="#E8ACAC" stroke-dasharray="1,2" stroke-miterlimit="10" width="40" x="20" y="4" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="1,1" stroke-miterlimit="10" x1="4" x2="20" y1="4" y2="60" /><g>
+			<g>
+				<line fill="none" stroke="#FFFFFF" stroke-miterlimit="10" x1="12" x2="9.108887" y1="2" y2="2.722656" />
+				<g>
+					<polygon fill="#FFFFFF" points="10.629883,0.595215 9.395508,2.650879 11.452148,3.884277 10.055664,4.233398 8,3        9.233398,0.944336      " />
+				</g>
+			</g>
+		</g>
+</svg>
+</span>
+</p>
 
 <h3>2.1&nbsp;&nbsp;<a href="test_alignrel_genfromSVG.html">Align relative</a></h3>
 
@@ -400,7 +441,7 @@ Thank you for your contribution!
 
 
 <footer>
-<p><b>Version 0.0.3</b></p>
+<p><b>Version 0.0.4</b></p>
 </footer>
 
 <script src="../spec/spec_DOMrefsheet.js"></script>

--- a/tests/test_alignabs_genfromSVG.html
+++ b/tests/test_alignabs_genfromSVG.html
@@ -140,7 +140,7 @@
 
 
 <footer>
-<p><b>Version 0.0.3</b></p>
+<p><b>Version 0.0.4</b></p>
 </footer>
 
 <script src="../spec/spec_DOMrefsheet.js"></script>

--- a/tests/test_alignrel_genfromSVG.html
+++ b/tests/test_alignrel_genfromSVG.html
@@ -139,7 +139,7 @@
 
 
 <footer>
-<p><b>Version 0.0.3</b></p>
+<p><b>Version 0.0.4</b></p>
 </footer>
 
 <script src="../spec/spec_DOMrefsheet.js"></script>

--- a/tests/test_controlflow_genfromSVG.html
+++ b/tests/test_controlflow_genfromSVG.html
@@ -665,7 +665,7 @@
 
 
 <footer>
-<p><b>Version 0.0.3</b></p>
+<p><b>Version 0.0.4</b></p>
 </footer>
 
 <script src="../spec/spec_DOMrefsheet.js"></script>

--- a/tests/test_create+destroy_genfromSVG.html
+++ b/tests/test_create+destroy_genfromSVG.html
@@ -173,7 +173,7 @@
 
 
 <footer>
-<p><b>Version 0.0.3</b></p>
+<p><b>Version 0.0.4</b></p>
 </footer>
 
 <script src="../spec/spec_DOMrefsheet.js"></script>

--- a/tests/test_moveabs_genfromSVG.html
+++ b/tests/test_moveabs_genfromSVG.html
@@ -117,7 +117,7 @@
 
 
 <footer>
-<p><b>Version 0.0.3</b></p>
+<p><b>Version 0.0.4</b></p>
 </footer>
 
 <script src="../spec/spec_DOMrefsheet.js"></script>

--- a/tests/test_moverel_genfromSVG.html
+++ b/tests/test_moverel_genfromSVG.html
@@ -145,7 +145,7 @@
 
 
 <footer>
-<p><b>Version 0.0.3</b></p>
+<p><b>Version 0.0.4</b></p>
 </footer>
 
 <script src="../spec/spec_DOMrefsheet.js"></script>

--- a/tests/test_scale+resize_genfromSVG.html
+++ b/tests/test_scale+resize_genfromSVG.html
@@ -458,7 +458,7 @@
 
 
 <footer>
-<p><b>Version 0.0.3</b></p>
+<p><b>Version 0.0.4</b></p>
 </footer>
 
 <script src="../spec/spec_DOMrefsheet.js"></script>

--- a/tests/test_selectors_genfromSVG.html
+++ b/tests/test_selectors_genfromSVG.html
@@ -127,7 +127,7 @@
 </svg>
 </span>
 </p>
-<p>Select by an enclosing rectangle. A connector allows to define selection rectangles that are remote from the point of attachment (upper left corner). <br><span class="testmetainfo">[selectionset 4,4 #9E005D] expected to fail.</span></p>
+<p>Select by an enclosing rectangle. A connector allows to define selection rectangles that are remote from the point of attachment (upper left corner). <br><span class="testmetainfo">[selectionset 4,4 #9E005D] expected to pass.</span></p>
 <!-- NOTE: The first three items in class list define the test. Handle with care! -->
 <p class="DOMreftest selectionset 4,4 #9E005D" id="enclose2">
 <span class="pre-reference">
@@ -382,7 +382,7 @@
 
 
 <footer>
-<p><b>Version 0.0.3</b></p>
+<p><b>Version 0.0.4</b></p>
 </footer>
 
 <script src="../spec/spec_DOMrefsheet.js"></script>

--- a/tests/toc.html
+++ b/tests/toc.html
@@ -177,7 +177,7 @@ C.&nbsp;&nbsp;<a href="failing.html">Appendix: Expected to fail</a>
 
 
 <footer>
-<p><b>Version 0.0.3</b></p>
+<p><b>Version 0.0.4</b></p>
 </footer>
 
 <script src="../spec/spec_DOMrefsheet.js"></script>


### PR DESCRIPTION
Variable renamings: `ICS0`, `ICS1` ... and the corresponding `I0`, `S0`, ...  

`retrieveCoreSelector` takes the `S` part of some `ICS` compound and returns a selector type (`RECTSELECTOR`, `UNKNOWNSELECTOR`) and a core selector. 

`selectedElementSet` takes the core selector and returns set of selected elements.
In the future, depending on the selector type, other methods will handle the core selector, for example for lenths.

Adapt the spec for selector tests to match the new retrieval+selection scheme.

Reference test sheets are now at Version 0.0.4 -- `enclose2` now passes.