### PR TITLE
Object retrieval robust against viewbBox settings 

### DIFF
--- a/js/clip8.js
+++ b/js/clip8.js
@@ -499,12 +499,13 @@ var Clip8 = {
                             var stripe = stripeNaboveNbelow[0];
                             var above = stripeNaboveNbelow[1];
                             var below = stripeNaboveNbelow[2];
+
                             if (debug) console.log("[executeOneOperation] stripe, above, below:", stripe, above, below);
-                            var hitlist = svgroot.getEnclosureList(stripe, svgroot);
+                            var hitlist = Svgretrieve.getEnclosedElements(stripe, svgroot);
                             if (debug) console.log("[executeOneOperation] hitlist:", hitlist);
                             var selectedelements1 = []
                             for (var i = 0; i < hitlist.length; i++)
-                                if ( svgroot.checkIntersection(hitlist[i], above) && svgroot.checkIntersection(hitlist[i], below) )
+                                if ( Svgretrieve.checkIntersected(hitlist[i], above, svgroot) && Svgretrieve.checkIntersected(hitlist[i], below, svgroot) )
                                     selectedelements1.push(hitlist[i]);
                             if (debug) console.log("[executeOneOperation] selectedelements1:", selectedelements1);
                             Paperclip.cutHorizontal(selectedelements1, theline.getAttribute("y1"));

--- a/js/clip8.js
+++ b/js/clip8.js
@@ -103,7 +103,7 @@ var Clip8 = {
     retrieveISCElements: function (arearect, svgroot, tagsI, tagsS, tagsC) {
         var debug = false;
         if (debug) console.log("[RETRIEVEISCELEMENTS] arearect, svgroot:", arearect, svgroot);
-        var hitlist = svgroot.getIntersectionList(arearect, svgroot);
+        var hitlist = Svgretrieve.getIntersectedElements(arearect, svgroot);
         if (debug)  console.log("[retrieveISCElements] hitlist:", hitlist);
         hitlist = Clip8.removeFalsePositives(arearect, hitlist);
         if (debug)  console.log("[retrieveISCElements] hitlist (red):", hitlist);
@@ -350,7 +350,7 @@ var Clip8 = {
                 // found circle not surrounded by any other (= an area being the centre of one circle).
                 var hit = centres_offilled[i];
                 var hitarea = Svgdom.epsilonRectAt(hit, epsilon, svgroot);
-                var hitlist = svgroot.getIntersectionList(hitarea, svgroot);
+                var hitlist = Svgretrieve.getIntersectedElements(hitarea, svgroot);
                 if (debug) console.log("[initControlFlow] , hit, hitarea, hitlist:", hit, hitarea, hitlist);
                 for ( var k = 0; k < hitlist.length; k++ ) {
                     if (hitlist[k].tagName == "path") {

--- a/js/clip8.js
+++ b/js/clip8.js
@@ -184,7 +184,11 @@ var Clip8 = {
         if (selectorcore[0] instanceof SVGRectElement) {
             // rectangle
             var dashes = selectorcore[0].getAttribute("stroke-dasharray").split(",").map(parseFloat);
-            s = Svgretrieve.selectorFromRect(selectorcore[0], svgroot);
+            s = svgroot.createSVGRect();
+            s.x = selectorcore[0].x.baseVal.value;
+            s.y = selectorcore[0].y.baseVal.value;
+            s.width = selectorcore[0].width.baseVal.value;
+            s.height = selectorcore[0].height.baseVal.value;
         }
         else if (selectorcore[0] instanceof SVGLineElement && selectorcore[1] instanceof SVGLineElement) {
             // DELETE: X icon defines the selection area
@@ -207,9 +211,9 @@ var Clip8 = {
         }
         if (debug) console.log("[selectedElementSet] selector from selectorcore:", s);
         if (dashes.length == 2 && dashes[0] < dashes[1] )
-            hitlist = svgroot.getEnclosureList(s, svgroot);
+            hitlist = Svgretrieve.getEnclosedElements(s, svgroot);
         else if (dashes.length == 2 && dashes[0] > dashes[1] )
-            hitlist = svgroot.getIntersectionList(s, svgroot);
+            hitlist = Svgretrieve.getIntersectedElements(s, svgroot);
         else throw "[selectedElementSet] invalid dash pattern."
         for ( var i = 0; i < hitlist.length; i++ )
             if ( hitlist[i].tagName == "rect" &&

--- a/js/svgdom.js
+++ b/js/svgdom.js
@@ -66,7 +66,7 @@ var Svgdom = {
         return r;
     },
 
-    newRectElement_fromSVGRect (r) {
+    newRectElement_fromSVGRect: function (r) {
         return Svgdom.newRectElement(r.x, r.y, r.width, r.height);
     },
 

--- a/js/svgdom.js
+++ b/js/svgdom.js
@@ -43,6 +43,17 @@ var Svgdom = {
         return r;
     },
 
+    newSVGRect_fromPoints: function (p1, p2, svgroot) {
+        /** Create a new SVGRect.
+        */
+        var r = svgroot.createSVGRect();
+        r.x = Math.min(p1.x, p2.x);
+        r.y = Math.min(p1.y, p2.y);
+        r.width = Math.abs(p2.x-p1.x);
+        r.height = Math.abs(p2.y-p1.y);
+        return r;
+    },
+
     newRectElement: function (x,y,w,h) {
         /** Create an SVG DOM rect element */
         var debug = false;

--- a/js/svgretrieve.js
+++ b/js/svgretrieve.js
@@ -36,7 +36,7 @@ var Svgretrieve = {
         y2 = line.y2.baseVal.value;
         vBy = svgcontainer.getAttribute("viewBox").split(" ")[1];
         vBh = svgcontainer.getAttribute("viewBox").split(" ")[3];
-        
+
         p1 = svgcontainer.createSVGPoint();
         p2 = svgcontainer.createSVGPoint();
         p1.x = x1;
@@ -69,64 +69,30 @@ var Svgretrieve = {
         throw "[enclosingFullWidthStripe] not implemented."
     },
 
+    _transformRect_svg2view: function (svgrect, svgroot) {
+        var trafo = svgroot.getCTM();
+        var p1 = svgroot.createSVGPoint();
+        var p2 = svgroot.createSVGPoint();
+        p1.x = svgrect.x;
+        p1.y = svgrect.y;
+        p2.x = svgrect.x + svgrect.width;
+        p2.y = svgrect.y + svgrect.height;
+        p1 = p1.matrixTransform(trafo);
+        p2 = p2.matrixTransform(trafo);
+        return Svgdom.newSVGRect_fromPoints(p1, p2, svgroot);
+    },
+
     getIntersectedElements: function(arearect, svgroot) {
-        var trafo = svgroot.getCTM();
-
-        var p1 = svgroot.createSVGPoint();
-        var p2 = svgroot.createSVGPoint();
-        p1.x = arearect.x;
-        p1.y = arearect.y;
-        p2.x = arearect.x + arearect.width;
-        p2.y = arearect.y + arearect.height;
-        p1 = p1.matrixTransform(trafo);
-        p2 = p2.matrixTransform(trafo);
-        var transformedrect = Svgdom.newSVGRect_fromPoints(p1, p2, svgroot);
-        return svgroot.getIntersectionList(transformedrect, svgroot);
+        return svgroot.getIntersectionList(Svgretrieve._transformRect_svg2view(arearect, svgroot), svgroot);
     },
-
     getEnclosedElements: function(arearect, svgroot) {
-        var trafo = svgroot.getCTM();
-
-        var p1 = svgroot.createSVGPoint();
-        var p2 = svgroot.createSVGPoint();
-        p1.x = arearect.x;
-        p1.y = arearect.y;
-        p2.x = arearect.x + arearect.width;
-        p2.y = arearect.y + arearect.height;
-        p1 = p1.matrixTransform(trafo);
-        p2 = p2.matrixTransform(trafo);
-        var transformedrect = Svgdom.newSVGRect_fromPoints(p1, p2, svgroot);
-        return svgroot.getEnclosureList(transformedrect, svgroot);
+        return svgroot.getEnclosureList(Svgretrieve._transformRect_svg2view(arearect, svgroot), svgroot);
     },
-
     checkIntersected: function(el, arearect, svgroot) {
-        var trafo = svgroot.getCTM();
-
-        var p1 = svgroot.createSVGPoint();
-        var p2 = svgroot.createSVGPoint();
-        p1.x = arearect.x;
-        p1.y = arearect.y;
-        p2.x = arearect.x + arearect.width;
-        p2.y = arearect.y + arearect.height;
-        p1 = p1.matrixTransform(trafo);
-        p2 = p2.matrixTransform(trafo);
-        var transformedrect = Svgdom.newSVGRect_fromPoints(p1, p2, svgroot);
-        return svgroot.checkIntersection(el, transformedrect);
+        return svgroot.checkIntersection(el, Svgretrieve._transformRect_svg2view(arearect, svgroot));
     },
-
     checkEnclosed: function(el, arearect, svgroot) {
-        var trafo = svgroot.getCTM();
-
-        var p1 = svgroot.createSVGPoint();
-        var p2 = svgroot.createSVGPoint();
-        p1.x = arearect.x;
-        p1.y = arearect.y;
-        p2.x = arearect.x + arearect.width;
-        p2.y = arearect.y + arearect.height;
-        p1 = p1.matrixTransform(trafo);
-        p2 = p2.matrixTransform(trafo);
-        var transformedrect = Svgdom.newSVGRect_fromPoints(p1, p2, svgroot);
-        return svgroot.checkEnclosure(el, transformedrect);
+        return svgroot.checkEnclosure(el, Svgretrieve._transformRect_svg2view(arearect, svgroot));
     },
 
     getCirclesAt: function(c, r1, r2, svgcontainer) {

--- a/js/svgretrieve.js
+++ b/js/svgretrieve.js
@@ -47,7 +47,6 @@ var Svgretrieve = {
             points.map ( function (p) { return p.matrixTransform(trafos[i]); } );
         return points;
     },
-
     selectorFromRect: function (rect, svgcontainer) {
         /** Derive a enclosure/intersection rectangle from a DOM rect element.
         *   FIXME: Handle svg viewBox attributes with x, y != 0
@@ -121,7 +120,19 @@ var Svgretrieve = {
     },
 
     getEnclosedElements: function(arearect, svgroot) {
-        return svgroot.getIntersectionList(arearect, svgroot);
+        //console.log("[getEnclosedElements]", arearect, svgroot);
+        var trafo = svgroot.getCTM();
+
+        var p1 = svgroot.createSVGPoint();
+        var p2 = svgroot.createSVGPoint();
+        p1.x = arearect.x;
+        p1.y = arearect.y;
+        p2.x = arearect.x + arearect.width;
+        p2.y = arearect.y + arearect.height;
+        p1 = p1.matrixTransform(trafo);
+        p2 = p2.matrixTransform(trafo);
+        var transformedrect = Svgdom.newSVGRect_fromPoints(p1, p2, svgroot);
+        return svgroot.getIntersectionList(transformedrect, svgroot);
     },
 
     getCirclesAt: function(c, r1, r2, svgcontainer) {

--- a/js/svgretrieve.js
+++ b/js/svgretrieve.js
@@ -120,6 +120,10 @@ var Svgretrieve = {
         throw "[enclosingFullWidthStripe] not implemented."
     },
 
+    getEnclosedElements: function(arearect, svgroot) {
+        return svgroot.getIntersectionList(arearect, svgroot);
+    },
+
     getCirclesAt: function(c, r1, r2, svgcontainer) {
         /** Return all circles roughly centred at `c` with a radius `r1 < radius < r2` (approximately).
         */

--- a/js/svgretrieve.js
+++ b/js/svgretrieve.js
@@ -119,7 +119,7 @@ var Svgretrieve = {
         throw "[enclosingFullWidthStripe] not implemented."
     },
 
-    getEnclosedElements: function(arearect, svgroot) {
+    getIntersectedElements: function(arearect, svgroot) {
         //console.log("[getEnclosedElements]", arearect, svgroot);
         var trafo = svgroot.getCTM();
 

--- a/js/svgretrieve.js
+++ b/js/svgretrieve.js
@@ -47,28 +47,6 @@ var Svgretrieve = {
             points.map ( function (p) { return p.matrixTransform(trafos[i]); } );
         return points;
     },
-    selectorFromRect: function (rect, svgcontainer) {
-        /** Derive a enclosure/intersection rectangle from a DOM rect element.
-        *   FIXME: Handle svg viewBox attributes with x, y != 0
-        */
-        var debug = false;
-        var trafos = Svgretrieve._collectTrafos(rect, svgcontainer)
-        // make p1 and p2 the edges of rect
-        var points = [svgcontainer.createSVGPoint(), svgcontainer.createSVGPoint()];
-        points[0].x = rect.x.baseVal.value;
-        points[0].y = rect.y.baseVal.value;
-        points[1].x = points[0].x + rect.width.baseVal.value;
-        points[1].y = points[0].y + rect.height.baseVal.value;
-        Svgretrieve._applyTrafos(points, trafos);
-        // turn the points back into a rectangle (depending on the arrangement of `p1, p2`)
-        var r = svgcontainer.createSVGRect();
-        if (points[0].x < points[1].x)  { r.x = points[0].x; r.width  = points[1].x - points[0].x; }
-        else                            { r.x = points[1].x; r.width  = points[0].x - points[1].x; }
-        if (points[0].y < points[1].y)  { r.y = points[0].y; r.height = points[1].y - points[0].y; }
-        else                            { r.y = points[1].y; r.height = points[0].y - points[1].y; }
-        if (debug) console.log("selector", r);
-        return r;
-    },
 
     enclosingFullHeightStripe: function(line, svgcontainer) {
         /*  Determine the horizontal boundaries enclosing `line`.
@@ -120,7 +98,6 @@ var Svgretrieve = {
     },
 
     getIntersectedElements: function(arearect, svgroot) {
-        //console.log("[getEnclosedElements]", arearect, svgroot);
         var trafo = svgroot.getCTM();
 
         var p1 = svgroot.createSVGPoint();
@@ -133,6 +110,21 @@ var Svgretrieve = {
         p2 = p2.matrixTransform(trafo);
         var transformedrect = Svgdom.newSVGRect_fromPoints(p1, p2, svgroot);
         return svgroot.getIntersectionList(transformedrect, svgroot);
+    },
+
+    getEnclosedElements: function(arearect, svgroot) {
+        var trafo = svgroot.getCTM();
+
+        var p1 = svgroot.createSVGPoint();
+        var p2 = svgroot.createSVGPoint();
+        p1.x = arearect.x;
+        p1.y = arearect.y;
+        p2.x = arearect.x + arearect.width;
+        p2.y = arearect.y + arearect.height;
+        p1 = p1.matrixTransform(trafo);
+        p2 = p2.matrixTransform(trafo);
+        var transformedrect = Svgdom.newSVGRect_fromPoints(p1, p2, svgroot);
+        return svgroot.getEnclosureList(transformedrect, svgroot);
     },
 
     getCirclesAt: function(c, r1, r2, svgcontainer) {

--- a/js/svgretrieve.js
+++ b/js/svgretrieve.js
@@ -151,12 +151,12 @@ var Svgretrieve = {
                 r.setAttribute("fill", "#ffff22");
             }
         }
-        candidates = svgcontainer.getIntersectionList(testareas[0], svgcontainer);
+        candidates = Svgretrieve.getIntersectedElements(testareas[0], svgcontainer);
         for (var i = 0; i < candidates.length; i++) {
             if (candidates[i] instanceof SVGCircleElement) {
                 var reject = false;     // reject the currently tested candidate?
                 for (var j = 1; j < testareas.length; j++) {
-                    if ( ! svgcontainer.checkIntersection(candidates[i], testareas[j]) ) {
+                    if ( ! Svgretrieve.checkIntersected(candidates[i], testareas[j], svgcontainer) ) {
                         reject = true;
                         break;
                     }
@@ -186,13 +186,13 @@ var Svgretrieve = {
                 r.setAttribute("fill", "#ffff22");
             }
         }
-        candidates = svgcontainer.getIntersectionList(testareas[0], svgcontainer);
+        candidates = Svgretrieve.getIntersectedElements(testareas[0], svgcontainer);
         if (debug) console.log("[getLinesFromTo] candidates", candidates);
         for (var i = 0; i < candidates.length; i++) {
             if (candidates[i] instanceof SVGLineElement) {
                 var reject = false;     // reject the currently tested candidate?
                 for (var j = 1; j < testareas.length; j++) {
-                    if ( ! svgcontainer.checkIntersection(candidates[i], testareas[j]) ) {
+                    if ( ! Svgretrieve.checkIntersected(candidates[i], testareas[j], svgcontainer) ) {
                         reject = true;
                         break;
                     }

--- a/spec/spec_DOMrefsheet.js
+++ b/spec/spec_DOMrefsheet.js
@@ -179,7 +179,7 @@ function addTest_selectionset(reftestElement, p0x, p0y, color) {
         p0.y = p0y;
         var arearect = Svgdom.epsilonRectAt(p0, epsilon, svgroot);
         Clip8.blocklist = [];   // reset the blocklist; we are fetching a new instruction
-        var sel = svgroot.getIntersectionList(arearect, svgroot);
+        var sel = Svgretrieve.getIntersectedElements(arearect, svgroot);
         var S = []
         for ( var i = 0; i < Clip8.TAGS.length; i++ ) S.push([]);
         for ( var i = 0; i < sel.length; i++ )

--- a/spec/svgretrieve-spec.js
+++ b/spec/svgretrieve-spec.js
@@ -1,4 +1,4 @@
-describe("getEnclosedElements", function() {
+describe("getIntersectedElements", function() {
     var svgroot;
 
     var putandretrieve_circles = function () {
@@ -20,7 +20,7 @@ describe("getEnclosedElements", function() {
             arearect.y = cy-1.0;
             arearect.width = 2.0;
             arearect.height = 2.0;
-            hitlist = Svgretrieve.getEnclosedElements(arearect, svgroot);
+            hitlist = Svgretrieve.getIntersectedElements(arearect, svgroot);
             expect(hitlist.length).toBe(1, "to find exactly one circle in the hitlist");
             expect(hitlist[0] instanceof SVGCircleElement).toBe(true, "retrieved element to be instance of SVGCircleElement");
             svgroot.removeChild(svgroot.firstChild);

--- a/spec/svgretrieve-spec.js
+++ b/spec/svgretrieve-spec.js
@@ -6,6 +6,9 @@ describe("getEnclosedElements", function() {
         while (svgroot.firstChild) {
             svgroot.removeChild(svgroot.firstChild);
         }
+        svgroot.setAttribute("width", 100);
+        svgroot.setAttribute("height", 100);
+        svgroot.setAttribute("viewBox", "0 0 100 100");
     });
 
     it("retreives elements from a SVG container", function() {

--- a/spec/svgretrieve-spec.js
+++ b/spec/svgretrieve-spec.js
@@ -1,6 +1,32 @@
 describe("getEnclosedElements", function() {
     var svgroot;
 
+    var putandretrieve_circles = function () {
+        var cx, cy, circ, arearect, hitlist;
+
+        for (var i = 0; i<200; i++) {
+            expect(svgroot.firstChild).toBe(null);
+            cx = Math.random()*100.0;
+            cy = Math.random()*100.0;
+            circ = document.createElementNS(svgroot.namespaceURI,"circle");
+            circ.setAttribute("cx", cx);
+            circ.setAttribute("cy", cy);
+            circ.setAttribute("fill", "#000000;");
+            circ.setAttribute("r", 0.999);
+            svgroot.appendChild(circ);
+
+            arearect = svgroot.createSVGRect();
+            arearect.x = cx-1.0;
+            arearect.y = cy-1.0;
+            arearect.width = 2.0;
+            arearect.height = 2.0;
+            hitlist = Svgretrieve.getEnclosedElements(arearect, svgroot);
+            expect(hitlist.length).toBe(1, "to find exactly one circle in the hitlist");
+            expect(hitlist[0] instanceof SVGCircleElement).toBe(true, "retrieved element to be instance of SVGCircleElement");
+            svgroot.removeChild(svgroot.firstChild);
+        }
+    };
+
     beforeEach(function() {
         svgroot = document.getElementById("svgroot1");
         while (svgroot.firstChild) {
@@ -11,58 +37,29 @@ describe("getEnclosedElements", function() {
         svgroot.setAttribute("viewBox", "0 0 100 100");
     });
 
-    it("retreives elements from a SVG container", function() {
+    it("retreives elements from an SVG container", function() {
         expect(svgroot instanceof SVGElement).toBe(true);
-        var cx, cy, circ, arearect, hitlist;
-
-        for (var i = 0; i<200; i++) {
-            expect(svgroot.firstChild).toBe(null);
-            cx = Math.random()*100.0;
-            cy = Math.random()*100.0;
-            circ = document.createElementNS(svgroot.namespaceURI,"circle");
-            circ.setAttribute("cx", cx);
-            circ.setAttribute("cy", cy);
-            circ.setAttribute("fill", "#000000;");
-            circ.setAttribute("r", 0.999);
-            svgroot.appendChild(circ);
-
-            arearect = svgroot.createSVGRect();
-            arearect.x = cx-1.0
-            arearect.y = cy-1.0;
-            arearect.width = 2.0;
-            arearect.height = 2.0;
-            hitlist = Svgretrieve.getEnclosedElements(arearect, svgroot);
-            expect(hitlist.length).toBe(1);
-            expect(hitlist[0] instanceof SVGCircleElement).toBe(true);
-            svgroot.removeChild(svgroot.firstChild);
-        }
+        putandretrieve_circles();
     });
     it("retreives elements from a resized SVG container", function() {
         expect(svgroot instanceof SVGElement).toBe(true);
         svgroot.setAttribute("width", 150);
         svgroot.setAttribute("height", 150);
-        var cx, cy, circ, arearect, hitlist;
-
-        for (var i = 0; i<200; i++) {
-            expect(svgroot.firstChild).toBe(null);
-            cx = Math.random()*100.0;
-            cy = Math.random()*100.0;
-            circ = document.createElementNS(svgroot.namespaceURI,"circle");
-            circ.setAttribute("cx", cx);
-            circ.setAttribute("cy", cy);
-            circ.setAttribute("fill", "#000000;");
-            circ.setAttribute("r", 0.999);
-            svgroot.appendChild(circ);
-
-            arearect = svgroot.createSVGRect();
-            arearect.x = cx-1.0
-            arearect.y = cy-1.0;
-            arearect.width = 2.0;
-            arearect.height = 2.0;
-            hitlist = Svgretrieve.getEnclosedElements(arearect, svgroot);
-            expect(hitlist.length).toBe(1);
-            expect(hitlist[0] instanceof SVGCircleElement).toBe(true);
-            svgroot.removeChild(svgroot.firstChild);
-        }
+        putandretrieve_circles();
+    });
+    it("retreives elements from an SVG container with a resized viewBox", function() {
+        expect(svgroot instanceof SVGElement).toBe(true);
+        svgroot.setAttribute("viewBox", "0 0 60 60");
+        putandretrieve_circles();
+    });
+    it("retreives elements from an SVG container with a moved viewBox", function() {
+        expect(svgroot instanceof SVGElement).toBe(true);
+        svgroot.setAttribute("viewBox", "10 10 100 100");
+        putandretrieve_circles();
+    });
+    it("retreives elements from an SVG container with a non-trivial viewBox", function() {
+        expect(svgroot instanceof SVGElement).toBe(true);
+        svgroot.setAttribute("viewBox", "10 10 140 140");
+        putandretrieve_circles();
     });
 });

--- a/spec/svgretrieve-spec.js
+++ b/spec/svgretrieve-spec.js
@@ -1,0 +1,65 @@
+describe("getEnclosedElements", function() {
+    var svgroot;
+
+    beforeEach(function() {
+        svgroot = document.getElementById("svgroot1");
+        while (svgroot.firstChild) {
+            svgroot.removeChild(svgroot.firstChild);
+        }
+    });
+
+    it("retreives elements from a SVG container", function() {
+        expect(svgroot instanceof SVGElement).toBe(true);
+        var cx, cy, circ, arearect, hitlist;
+
+        for (var i = 0; i<200; i++) {
+            expect(svgroot.firstChild).toBe(null);
+            cx = Math.random()*100.0;
+            cy = Math.random()*100.0;
+            circ = document.createElementNS(svgroot.namespaceURI,"circle");
+            circ.setAttribute("cx", cx);
+            circ.setAttribute("cy", cy);
+            circ.setAttribute("fill", "#000000;");
+            circ.setAttribute("r", 0.999);
+            svgroot.appendChild(circ);
+
+            arearect = svgroot.createSVGRect();
+            arearect.x = cx-1.0
+            arearect.y = cy-1.0;
+            arearect.width = 2.0;
+            arearect.height = 2.0;
+            hitlist = Svgretrieve.getEnclosedElements(arearect, svgroot);
+            expect(hitlist.length).toBe(1);
+            expect(hitlist[0] instanceof SVGCircleElement).toBe(true);
+            svgroot.removeChild(svgroot.firstChild);
+        }
+    });
+    it("retreives elements from a resized SVG container", function() {
+        expect(svgroot instanceof SVGElement).toBe(true);
+        svgroot.setAttribute("width", 150);
+        svgroot.setAttribute("height", 150);
+        var cx, cy, circ, arearect, hitlist;
+
+        for (var i = 0; i<200; i++) {
+            expect(svgroot.firstChild).toBe(null);
+            cx = Math.random()*100.0;
+            cy = Math.random()*100.0;
+            circ = document.createElementNS(svgroot.namespaceURI,"circle");
+            circ.setAttribute("cx", cx);
+            circ.setAttribute("cy", cy);
+            circ.setAttribute("fill", "#000000;");
+            circ.setAttribute("r", 0.999);
+            svgroot.appendChild(circ);
+
+            arearect = svgroot.createSVGRect();
+            arearect.x = cx-1.0
+            arearect.y = cy-1.0;
+            arearect.width = 2.0;
+            arearect.height = 2.0;
+            hitlist = Svgretrieve.getEnclosedElements(arearect, svgroot);
+            expect(hitlist.length).toBe(1);
+            expect(hitlist[0] instanceof SVGCircleElement).toBe(true);
+            svgroot.removeChild(svgroot.firstChild);
+        }
+    });
+});

--- a/tests/runner_Svgretrieve.html
+++ b/tests/runner_Svgretrieve.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+<meta charset="utf-8">
+<title>test_8 | Svgretrieve</title>
+<link rel="shortcut icon" type="image/png" href="../lib/jasmine/lib/jasmine-2.5.2/jasmine_favicon.png">
+<link rel="stylesheet" href="../lib/jasmine/lib/jasmine-2.5.2/jasmine.css">
+<script src="../lib/jasmine/lib/jasmine-2.5.2/jasmine.js"></script>
+<script src="../lib/jasmine/lib/jasmine-2.5.2/jasmine-html.js"></script>
+<script src="../lib/jasmine/lib/jasmine-2.5.2/boot.js"></script>
+
+<link rel="stylesheet" href="../css/refsheet.css">
+<link rel="stylesheet" href="../css/clip8.css">
+<script src="../js/svgdom.js"></script>
+<script src="../js/svgretrieve.js"></script>
+<script src="../js/paperclip.js"></script>
+<script src="../js/clip8decode.js"></script>
+<script src="../js/clip8.js"></script>
+<!-- include source files here... -->
+<script src="../js/svgretrieve.js"></script>
+<!-- include spec files here... -->
+<script src="../spec/svgretrieve-spec.js"></script>
+</head>
+<body>
+<svg id="svgroot1" width="100px" height="100px" viewBox="0 0 100 100">
+</svg>
+</body>
+</html>

--- a/tests/runner_Svgretrieve.html
+++ b/tests/runner_Svgretrieve.html
@@ -23,7 +23,7 @@
 <script src="../spec/svgretrieve-spec.js"></script>
 </head>
 <body>
-<svg id="svgroot1" width="100px" height="100px" viewBox="0 0 100 100">
+<svg id="svgroot1">
 </svg>
 </body>
 </html>

--- a/tests/test-manual_viewbox-and-scale_passing-distorted.html
+++ b/tests/test-manual_viewbox-and-scale_passing-distorted.html
@@ -31,6 +31,7 @@
 </nav>
 <h1><span class="sndtitle">clip_8&nbsp;|</span>&nbsp;viewBox+size</h1>
 
+
 <p>If you encounter a failing test in this section, please consider <a href="https://github.com/broesamle/clip_8/issues">filing an issue</a>. It may indicate several things:
 <br>(a) By accident, the test is not in the list of tests that are expected to fail.
 <br>(b) clip_8 has, in principle, the functionality to pass the test. However, the current implementation relies on
@@ -42,10 +43,12 @@ some experimental features not supported by all browsers. Please refer to
 Thank you for your contribution!
 </p>
 
+<h2>viewbox="-60 0 104 164" width="64" height="64"</h2>
+
 <h3>1.1&nbsp;&nbsp;<a href="test_controlflow_genfromSVG.html">Control flow</a></h3>
 
 <!-- NOTE: The first three items in class list define the test. Handle with care! -->
-<p class="DOMreftest normal_execution 1" id="intitial-and-terminal">
+<p class="DOMreftest normal_execution 1" id="dist-intitial-and-terminal">
 <span class="pre-reference">
 <svg viewbox="-60 0 104 164" width="64" height="64">
 <circle cx="12" cy="32.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="47.75" cy="32" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="47.75" cy="32" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M12,32c9.75,9.999,19.75-5,35.75-0.013" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" />
@@ -65,7 +68,7 @@ Thank you for your contribution!
 </span>
 </p>
 <!-- NOTE: The first three items in class list define the test. Handle with care! -->
-<p class="DOMreftest normal_execution 1" id="intitial-and-terminal2">
+<p class="DOMreftest normal_execution 1" id="dist-intitial-and-terminal2">
 <span class="pre-reference">
 <svg viewbox="-60 0 104 164" width="64" height="64">
 <circle cx="12" cy="32.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="47.75" cy="32" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="47.75" cy="32" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M12,32.012c0,0,18.75,0,35.75-0.012" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" />
@@ -85,7 +88,7 @@ Thank you for your contribution!
 </span>
 </p>
 <!-- NOTE: The first three items in class list define the test. Handle with care! -->
-<p class="DOMreftest normal_execution 1" id="intitial-and-terminal3">
+<p class="DOMreftest normal_execution 1" id="dist-intitial-and-terminal3">
 <span class="pre-reference">
 <svg viewbox="-60 0 104 164" width="64" height="64">
 <circle cx="44.537" cy="44.05" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="17.419" cy="20.755" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="17.419" cy="20.755" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M44.537,44.051c0,0-14.219-12.223-27.119-23.295    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" />
@@ -105,7 +108,7 @@ Thank you for your contribution!
 </span>
 </p>
 <!-- NOTE: The first three items in class list define the test. Handle with care! -->
-<p class="DOMreftest normal_execution 3" id="alternative-join-combo">
+<p class="DOMreftest normal_execution 3" id="dist-alternative-join-combo">
 <span class="pre-reference">
 <svg viewbox="-60 0 104 164" width="64" height="64">
 <circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.25C29,31.25,29,31,20,31" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="18.375" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" />
@@ -125,7 +128,7 @@ Thank you for your contribution!
 </span>
 </p>
 <!-- NOTE: The first three items in class list define the test. Handle with care! -->
-<p class="DOMreftest normal_execution 3" id="alternative-join-combo2">
+<p class="DOMreftest normal_execution 3" id="dist-alternative-join-combo2">
 <span class="pre-reference">
 <svg viewbox="-60 0 104 164" width="64" height="64">
 <rect height="3.125" width="3.125" x="15.844" y="19.594" /><circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.25C29,31.25,29,31,20,31" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="18.375" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" />
@@ -145,7 +148,7 @@ Thank you for your contribution!
 </span>
 </p>
 <!-- NOTE: The first three items in class list define the test. Handle with care! -->
-<p class="DOMreftest normal_execution 4" id="alternative-join-combo3">
+<p class="DOMreftest normal_execution 4" id="dist-alternative-join-combo3">
 <span class="pre-reference">
 <svg viewbox="-60 0 104 164" width="64" height="64">
 <rect height="3.125" width="3.125" x="32.262" y="20.292" /><circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.25C29,31.25,29,31,20,31" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="18.375" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" />
@@ -165,7 +168,7 @@ Thank you for your contribution!
 </span>
 </p>
 <!-- NOTE: The first three items in class list define the test. Handle with care! -->
-<p class="DOMreftest normal_execution 3" id="alternative-join-combo4">
+<p class="DOMreftest normal_execution 3" id="dist-alternative-join-combo4">
 <span class="pre-reference">
 <svg viewbox="-60 0 104 164" width="64" height="64">
 <rect height="3.125" width="3.125" x="32.262" y="20.292" /><circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.25C29,31.25,29,31,20,31" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="31" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" />
@@ -185,7 +188,7 @@ Thank you for your contribution!
 </span>
 </p>
 <!-- NOTE: The first three items in class list define the test. Handle with care! -->
-<p class="DOMreftest normal_execution 4" id="alternative-join-combo5">
+<p class="DOMreftest normal_execution 4" id="dist-alternative-join-combo5">
 <span class="pre-reference">
 <svg viewbox="-60 0 104 164" width="64" height="64">
 <rect height="3.125" width="3.125" x="32.262" y="20.292" /><rect height="3.125" width="3.125" x="15.844" y="33.438" /><circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.25C29,31.25,29,31,20,31" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="31" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" />
@@ -205,7 +208,7 @@ Thank you for your contribution!
 </span>
 </p>
 <!-- NOTE: The first three items in class list define the test. Handle with care! -->
-<p class="DOMreftest normal_execution 4" id="disturbing-selector1">
+<p class="DOMreftest normal_execution 4" id="dist-disturbing-selector1">
 <span class="pre-reference">
 <svg viewbox="-60 0 104 164" width="64" height="64">
 <rect height="3.125" width="3.125" x="32.262" y="20.292" /><rect height="3.125" width="3.125" x="15.844" y="33.438" /><circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.25C29,31.25,29,31,20,31" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="31" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" /><rect fill="none" height="15.5" stroke="#990000" stroke-dasharray="1,2" stroke-miterlimit="10" width="17.125" x="9" y="31" />
@@ -225,7 +228,7 @@ Thank you for your contribution!
 </span>
 </p>
 <!-- NOTE: The first three items in class list define the test. Handle with care! -->
-<p class="DOMreftest normal_execution 4" id="disturbing-path1">
+<p class="DOMreftest normal_execution 4" id="dist-disturbing-path1">
 <span class="pre-reference">
 <svg viewbox="-60 0 104 164" width="64" height="64">
 <rect height="3.125" width="3.125" x="32.262" y="20.292" /><rect height="3.125" width="3.125" x="15.844" y="33.438" /><circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.253C29,31.253,29,31.003,20,31.003" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="31" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" /><path d="M1.741,31.003    c2.148,14.152,39.203,62.386,60.122,0" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" />
@@ -248,7 +251,7 @@ Thank you for your contribution!
 <h3>1.2&nbsp;&nbsp;<a href="test_selectors_genfromSVG.html">Selectors</a></h3>
 
 <!-- NOTE: The first three items in class list define the test. Handle with care! -->
-<p class="DOMreftest selectionset 4,4 #9E005D" id="enclose1">
+<p class="DOMreftest selectionset 4,4 #9E005D" id="dist-enclose1">
 <span class="pre-reference">
 <svg viewbox="-60 0 104 164" width="64" height="64">
 <rect height="20" width="28" x="28" y="12" /><rect height="16" width="11" x="45" y="36" /><rect height="40" width="16" x="8" y="12" /><rect fill="none" height="56" stroke="#E8ACAC" stroke-dasharray="1,2" stroke-miterlimit="10" width="36" x="4" y="4" /><g>
@@ -289,7 +292,7 @@ Thank you for your contribution!
 </span>
 </p>
 <!-- NOTE: The first three items in class list define the test. Handle with care! -->
-<p class="DOMreftest selectionset 4,4 #9E005D" id="enclose2">
+<p class="DOMreftest selectionset 4,4 #9E005D" id="dist-enclose2">
 <span class="pre-reference">
 <svg viewbox="-60 0 104 164" width="64" height="64">
 <rect height="20" width="28" x="28" y="12" /><rect height="16" width="11" x="45" y="36" /><rect height="40" width="16" x="8" y="12" /><rect fill="none" height="56" stroke="#E8ACAC" stroke-dasharray="1,2" stroke-miterlimit="10" width="40" x="20" y="4" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="1,1" stroke-miterlimit="10" x1="4" x2="20" y1="4" y2="60" /><g>
@@ -330,7 +333,7 @@ Thank you for your contribution!
 </span>
 </p>
 <!-- NOTE: The first three items in class list define the test. Handle with care! -->
-<p class="DOMreftest selectionset 4,4 #9E005D" id="intersect1">
+<p class="DOMreftest selectionset 4,4 #9E005D" id="dist-intersect1">
 <span class="pre-reference">
 <svg viewbox="-60 0 104 164" width="64" height="64">
 <rect height="20" width="28" x="28" y="12" /><rect height="16" width="11" x="45" y="36" /><rect height="40" width="16" x="8" y="12" /><rect fill="none" height="56" stroke="#E8ACAC" stroke-dasharray="3,1" stroke-miterlimit="10" width="36" x="4" y="4" /><g>
@@ -371,7 +374,7 @@ Thank you for your contribution!
 </span>
 </p>
 <!-- NOTE: The first three items in class list define the test. Handle with care! -->
-<p class="DOMreftest selectionset 4,4 #9E005D" id="intersect2">
+<p class="DOMreftest selectionset 4,4 #9E005D" id="dist-intersect2">
 <span class="pre-reference">
 <svg viewbox="-60 0 104 164" width="64" height="64">
 <rect height="20" width="28" x="28" y="12" /><rect height="16" width="11" x="45" y="36" /><rect height="40" width="16" x="8" y="12" /><rect fill="none" height="56" stroke="#E8ACAC" stroke-dasharray="3,1" stroke-miterlimit="10" width="24" x="36" y="4" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="1,1" stroke-miterlimit="10" x1="4" x2="36" y1="4" y2="60" /><g>
@@ -412,7 +415,7 @@ Thank you for your contribution!
 </span>
 </p>
 <!-- NOTE: The first three items in class list define the test. Handle with care! -->
-<p class="DOMreftest selectionset 4,4 #9E005D" id="intersect3">
+<p class="DOMreftest selectionset 4,4 #9E005D" id="dist-intersect3">
 <span class="pre-reference">
 <svg viewbox="-60 0 104 164" width="64" height="64">
 <rect height="20" width="28" x="28" y="12" /><rect height="16" width="11" x="45" y="36" /><rect height="40" width="16" x="8" y="12" /><rect fill="none" height="56" stroke="#E8ACAC" stroke-dasharray="3,1" stroke-miterlimit="10" width="24" x="36" y="4" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="0.866025,0.866025" stroke-miterlimit="10" stroke-width="0.866025" x1="36" x2="4" y1="60" y2="4" /><g>
@@ -456,7 +459,7 @@ Thank you for your contribution!
 <h3>1.3&nbsp;&nbsp;<a href="test_combine-instructions_genfromSVG.html">Combining Instructions</a></h3>
 
 <!-- NOTE: The first three items in class list define the test. Handle with care! -->
-<p class="DOMreftest normal_execution 3" id="two-moves1">
+<p class="DOMreftest normal_execution 3" id="dist-two-moves1">
 <span class="pre-reference">
 <svg viewbox="-60 0 104 164" width="64" height="64">
 <rect height="8" width="8" x="10" y="28" /><rect height="8" width="8" x="26" y="28" /><circle cx="36" cy="36" fill="none" r="2.5" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><line fill="none" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="36" x2="36" y1="24" y2="36" /><circle cx="20" cy="40" fill="none" r="2.5" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><line fill="none" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="20" x2="20" y1="24" y2="40" /><path d="M4,24.06c3.566,9.999,10.148-5,16-0.013" fill="none" stroke="#9ACDCD" stroke-miterlimit="10" stroke-width="0.5" /><path d="M20,24.06c3.565,9.998,10.149-4.999,16-0.013" fill="none" stroke="#9ACDCD" stroke-miterlimit="10" stroke-width="0.5" /><path d="M36,24.06c3.565,9.999,10.148-5,16-0.013" fill="none" stroke="#9ACDCD" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="52" cy="24" fill="#9ACDCD" r="1" stroke="#9ACDCD" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="52" cy="24" fill="none" r="2" stroke="#9ACDCD" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="none" height="37" stroke="#E5B7B7" stroke-dasharray="1,2" stroke-miterlimit="10" width="12" x="8" y="24" /><circle cx="4" cy="24" fill="#9ACDCD" r="1" stroke="#9ACDCD" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="none" height="37" stroke="#E5B7B7" stroke-dasharray="1,2" stroke-miterlimit="10" width="12" x="24" y="24" />
@@ -479,7 +482,7 @@ Thank you for your contribution!
 <h3>2.1&nbsp;&nbsp;<a href="test_alignrel_genfromSVG.html">Align relative</a></h3>
 
 <!-- NOTE: The first three items in class list define the test. Handle with care! -->
-<p class="DOMreftest normal_execution 2" id="align-rel-right">
+<p class="DOMreftest normal_execution 2" id="dist-align-rel-right">
 <span class="pre-reference">
 <svg viewbox="-60 0 104 164" width="64" height="64">
 <rect height="16" width="8" x="12" y="12" /><rect height="8" width="12" x="24" y="44" /><rect height="12" width="12" x="40" y="28" /><rect fill="none" height="46" stroke="#E5B7B7" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="60" x2="60" y1="10" y2="39" /><polyline fill="none" points="    57,12 60,10 57,8   " stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M60,10c0,0,5.367-3.318,0-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,56,1,56,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" />
@@ -499,7 +502,7 @@ Thank you for your contribution!
 </span>
 </p>
 <!-- NOTE: The first three items in class list define the test. Handle with care! -->
-<p class="DOMreftest normal_execution 2" id="align-rel-left">
+<p class="DOMreftest normal_execution 2" id="dist-align-rel-left">
 <span class="pre-reference">
 <svg viewbox="-60 0 104 164" width="64" height="64">
 <rect height="16" width="8" x="12" y="12" /><rect height="8" width="12" x="24" y="44" /><rect height="12" width="12" x="40" y="28" /><rect fill="none" height="46" stroke="#E5B7B7" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="8" x2="8" y1="10" y2="39" /><polyline fill="none" points="    11,12 8,10 11,8   " stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M8,10c0,0,52,0,52-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,4,0,4,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" />
@@ -519,7 +522,7 @@ Thank you for your contribution!
 </span>
 </p>
 <!-- NOTE: The first three items in class list define the test. Handle with care! -->
-<p class="DOMreftest normal_execution 2" id="align-rel-bottom">
+<p class="DOMreftest normal_execution 2" id="dist-align-rel-bottom">
 <span class="pre-reference">
 <svg viewbox="-60 0 104 164" width="64" height="64">
 <rect height="16" width="8" x="12" y="12" /><rect height="8" width="12" x="24" y="44" /><rect height="12" width="12" x="40" y="28" /><rect fill="none" height="46" stroke="#E5B7B7" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><line fill="none" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="8" x2="33" y1="56" y2="56" /><polyline fill="none" points="    10,53 8,56 6,53   " stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><path d="M8,56c15-1,52-28.653,52-52" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c3,3-1,31,4,52" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" />
@@ -539,7 +542,7 @@ Thank you for your contribution!
 </span>
 </p>
 <!-- NOTE: The first three items in class list define the test. Handle with care! -->
-<p class="DOMreftest normal_execution 2" id="align-rel-top">
+<p class="DOMreftest normal_execution 2" id="dist-align-rel-top">
 <span class="pre-reference">
 <svg viewbox="-60 0 104 164" width="64" height="64">
 <rect height="16" width="8" x="12" y="12" /><rect height="8" width="12" x="24" y="44" /><rect height="12" width="12" x="40" y="28" /><rect fill="none" height="46" stroke="#E5B7B7" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="8" x2="33" y1="10" y2="10" /><polyline fill="none" points="    10,13 8,10 6,13   " stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M6,5" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M8,10c0,0,52,0,52-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,4,0,4,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" />
@@ -562,7 +565,7 @@ Thank you for your contribution!
 <h3>2.2&nbsp;&nbsp;<a href="test_alignabs_genfromSVG.html">Align absolute</a></h3>
 
 <!-- NOTE: The first three items in class list define the test. Handle with care! -->
-<p class="DOMreftest normal_execution 2" id="align-abs-right">
+<p class="DOMreftest normal_execution 2" id="dist-align-abs-right">
 <span class="pre-reference">
 <svg viewbox="-60 0 104 164" width="64" height="64">
 <rect height="16" width="8" x="12" y="12" /><rect height="8" width="12" x="24" y="44" /><rect height="12" width="12" x="40" y="28" /><rect fill="none" height="46" stroke="#FF8888" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="60" x2="60" y1="10" y2="60" /><polyline fill="none" points="    57,12 60,10 57,8   " stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M60,10c0,0,5.367-3.318,0-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,56,1,56,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="#FF8888" height="5" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" width="5" x="55" y="55" />
@@ -582,7 +585,7 @@ Thank you for your contribution!
 </span>
 </p>
 <!-- NOTE: The first three items in class list define the test. Handle with care! -->
-<p class="DOMreftest normal_execution 2" id="align-abs-left">
+<p class="DOMreftest normal_execution 2" id="dist-align-abs-left">
 <span class="pre-reference">
 <svg viewbox="-60 0 104 164" width="64" height="64">
 <rect height="16" width="8" x="12" y="12" /><rect height="8" width="12" x="24" y="44" /><rect height="12" width="12" x="40" y="28" /><rect fill="none" height="46" stroke="#FF8888" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="8" x2="8" y1="10" y2="60" /><polyline fill="none" points="    11,12 8,10 11,8   " stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M8,10c0,0,52,0,52-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,4,0,4,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="#FF8888" height="5" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" width="5" x="8" y="55" />
@@ -602,7 +605,7 @@ Thank you for your contribution!
 </span>
 </p>
 <!-- NOTE: The first three items in class list define the test. Handle with care! -->
-<p class="DOMreftest normal_execution 2" id="align-abs-bottom">
+<p class="DOMreftest normal_execution 2" id="dist-align-abs-bottom">
 <span class="pre-reference">
 <svg viewbox="-60 0 104 164" width="64" height="64">
 <rect height="16" width="8" x="12" y="12" /><rect height="8" width="12" x="24" y="44" /><rect height="12" width="12" x="40" y="28" /><rect fill="none" height="46" stroke="#FF8888" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="8" x2="62" y1="56" y2="56" /><polyline fill="none" points="    10,53 8,56 6,53   " stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><path d="M8,56c15-1,52-28.653,52-52" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c3,3-1,31,4,52" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="#FF8888" height="5" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" width="5" x="57" y="51" />
@@ -622,7 +625,7 @@ Thank you for your contribution!
 </span>
 </p>
 <!-- NOTE: The first three items in class list define the test. Handle with care! -->
-<p class="DOMreftest normal_execution 2" id="align-abs-top">
+<p class="DOMreftest normal_execution 2" id="dist-align-abs-top">
 <span class="pre-reference">
 <svg viewbox="-60 0 104 164" width="64" height="64">
 <rect height="16" width="8" x="12" y="12" /><rect height="8" width="12" x="24" y="44" /><rect height="12" width="12" x="40" y="28" /><rect fill="none" height="46" stroke="#FF8888" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="8" x2="61" y1="10" y2="10" /><polyline fill="none" points="    10,13 8,10 6,13   " stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M6,5" fill="#990000" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M8,10c0,0,52,0,52-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,4,0,4,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="#FF8888" height="5" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" width="5" x="56" y="10" />
@@ -645,7 +648,7 @@ Thank you for your contribution!
 <h3>2.3&nbsp;&nbsp;<a href="test_moverel_genfromSVG.html">Move by vector (relative)</a></h3>
 
 <!-- NOTE: The first three items in class list define the test. Handle with care! -->
-<p class="DOMreftest normal_execution 2" id="move-rel-v-down">
+<p class="DOMreftest normal_execution 2" id="dist-move-rel-v-down">
 <span class="pre-reference">
 <svg viewbox="-60 0 104 164" width="64" height="64">
 <rect height="16" width="8" x="6" y="12" /><rect height="8" width="12" x="22" y="12" /><rect height="12" width="12" x="37" y="17" /><rect fill="none" height="46" stroke="#FF8888" stroke-dasharray="1,2" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="60" x2="60" y1="10" y2="43" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M60,10c0,0,5.367-3.318,0-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,56,1,56,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="43" fill="none" r="2.281" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" />
@@ -665,7 +668,7 @@ Thank you for your contribution!
 </span>
 </p>
 <!-- NOTE: The first three items in class list define the test. Handle with care! -->
-<p class="DOMreftest normal_execution 2" id="move-rel-dl">
+<p class="DOMreftest normal_execution 2" id="dist-move-rel-dl">
 <span class="pre-reference">
 <svg viewbox="-60 0 104 164" width="64" height="64">
 <rect height="8" width="12" x="22" y="12" /><rect height="12" width="12" x="37" y="17" /><rect fill="none" height="46" stroke="#FF8888" stroke-dasharray="1,2" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="60" x2="41" y1="10" y2="20" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M60,10c0,0,5.367-3.318,0-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,56,1,56,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="41" cy="20" fill="none" r="2.281" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" />
@@ -691,7 +694,7 @@ Thank you for your contribution!
 <h3>2.5&nbsp;&nbsp;<a href="test_create+destroy_genfromSVG.html">Create and destroy</a></h3>
 
 <!-- NOTE: The first three items in class list define the test. Handle with care! -->
-<p class="DOMreftest normal_execution 2" id="clone1">
+<p class="DOMreftest normal_execution 2" id="dist-clone1">
 <span class="pre-reference">
 <svg viewbox="-60 0 104 164" width="64" height="64">
 <rect height="32" stroke="#FFFFFF" stroke-miterlimit="10" width="22" x="21" y="19" /><circle cx="4" cy="4.012207" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M36,8c1-5,14-4,24-4" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c29,0,31-2,32,4" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="36" x2="40" y1="8" y2="16" /><rect fill="none" height="1" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" width="5" x="36" y="8" /><rect fill="none" height="1" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" width="5" x="40" y="16" /><rect fill="none" height="16" stroke="#FF8888" stroke-dasharray="3,1" stroke-miterlimit="10" width="8" x="28" y="8" />
@@ -711,7 +714,7 @@ Thank you for your contribution!
 </span>
 </p>
 <!-- NOTE: The first three items in class list define the test. Handle with care! -->
-<p class="DOMreftest normal_execution 2" id="cut-horiz">
+<p class="DOMreftest normal_execution 2" id="dist-cut-horiz">
 <span class="pre-reference">
 <svg viewbox="-60 0 104 164" width="64" height="64">
 <rect height="32" stroke="#FFFFFF" stroke-miterlimit="10" width="22" x="30" y="12" /><rect height="40" stroke="#FFFFFF" stroke-miterlimit="10" width="22" x="2" y="12" /><rect height="12" stroke="#FFFFFF" stroke-miterlimit="10" width="12" x="32" y="48" /><circle cx="4" cy="4.012207" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M56,34c2-2,9-20.625,4-30" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c53-2,54-2,52,30" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><line fill="none" stroke="#FF8888" stroke-dasharray="6,3" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="56" x2="17" y1="34" y2="34" />
@@ -731,7 +734,7 @@ Thank you for your contribution!
 </span>
 </p>
 <!-- NOTE: The first three items in class list define the test. Handle with care! -->
-<p class="DOMreftest normal_execution 2" id="delete1">
+<p class="DOMreftest normal_execution 2" id="dist-delete1">
 <span class="pre-reference">
 <svg viewbox="-60 0 104 164" width="64" height="64">
 <rect height="40" stroke="#A0A0A0" stroke-miterlimit="10" width="22" x="2" y="12" /><rect height="12" stroke="#A0A0A0" stroke-miterlimit="10" width="12" x="32" y="48" /><rect height="32" stroke="#A0A0A0" stroke-miterlimit="10" width="22" x="30" y="12" /><circle cx="4" cy="4.012207" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M27,8c0-4,25-4,33-4" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c11,0,23,0,23,4" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="6,3" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="55" x2="27" y1="52" y2="8" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="6,3" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="27" x2="55" y1="52" y2="8" />
@@ -751,7 +754,7 @@ Thank you for your contribution!
 </span>
 </p>
 <!-- NOTE: The first three items in class list define the test. Handle with care! -->
-<p class="DOMreftest normal_execution 2" id="delete2">
+<p class="DOMreftest normal_execution 2" id="dist-delete2">
 <span class="pre-reference">
 <svg viewbox="-60 0 104 164" width="64" height="64">
 <rect height="40" stroke="#A0A0A0" stroke-miterlimit="10" width="22" x="2" y="12" /><rect height="12" stroke="#A0A0A0" stroke-miterlimit="10" width="12" x="32" y="48" /><rect height="32" stroke="#A0A0A0" stroke-miterlimit="10" width="22" x="30" y="12" /><circle cx="4" cy="4.012207" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M27,8c0-4,25-4,33-4" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c11,0,23,0,23,4" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="1,5" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="55" x2="27" y1="52" y2="8" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="1,5" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="27" x2="55" y1="52" y2="8" />
@@ -774,7 +777,7 @@ Thank you for your contribution!
 <h3>3.1&nbsp;&nbsp;<a href="test_scale+resize_genfromSVG.html">Scale and resize</a></h3>
 
 <!-- NOTE: The first three items in class list define the test. Handle with care! -->
-<p class="DOMreftest normal_execution 2" id="shrink-upper">
+<p class="DOMreftest normal_execution 2" id="dist-shrink-upper">
 <span class="pre-reference">
 <svg viewbox="-60 0 104 164" width="64" height="64">
 <rect height="7" width="4" x="14" y="30" /><rect height="3" width="10" x="23" y="31" /><rect height="10" width="6" x="38" y="26" /><rect height="7" width="1" x="49" y="37" /><circle cx="59.896" cy="7.988" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="59.896" cy="7.988" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="4" cy="8" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M12,24C26,24,38.898,8,59.896,7.988" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4.103,8.013C4,13,3,31,12,24" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="none" height="22" stroke="#E8ACAC" stroke-dasharray="2,4" stroke-miterlimit="10" width="40" x="12" y="24" /><line fill="none" stroke="#E8ACAC" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="12" x2="12" y1="19" y2="24" /><polyline fill="none" points="    10,21 12,24 14,21   " stroke="#E8ACAC" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" />
@@ -789,6 +792,761 @@ Thank you for your contribution!
 &nbsp;:&nbsp;&nbsp;&nbsp;
 <span class="testDOM">
 <svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="7" width="4" x="14" y="30" /><rect height="3" width="10" x="23" y="31" /><rect height="10" width="6" x="38" y="26" /><rect height="7" width="1" x="49" y="37" /><circle cx="59.896" cy="7.988" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="59.896" cy="7.988" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="4" cy="8" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M12,24C26,24,38.898,8,59.896,7.988" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4.103,8.013C4,13,3,31,12,24" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="none" height="22" stroke="#E8ACAC" stroke-dasharray="2,4" stroke-miterlimit="10" width="40" x="12" y="24" /><line fill="none" stroke="#E8ACAC" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="12" x2="12" y1="19" y2="24" /><polyline fill="none" points="    10,21 12,24 14,21   " stroke="#E8ACAC" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" />
+</svg>
+</span>
+</p>
+
+
+<h2>viewbox="0 0 64 64" width="164" height="164"</h2>
+
+<h3>1.1&nbsp;&nbsp;<a href="test_controlflow_genfromSVG.html">Control flow</a></h3>
+
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 1" id="size-intitial-and-terminal">
+<span class="pre-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<circle cx="12" cy="32.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="47.75" cy="32" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="47.75" cy="32" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M12,32c9.75,9.999,19.75-5,35.75-0.013" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<circle cx="12" cy="32.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="47.75" cy="32" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="47.75" cy="32" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M12,32c9.75,9.999,19.75-5,35.75-0.013" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<circle cx="12" cy="32.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="47.75" cy="32" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="47.75" cy="32" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M12,32c9.75,9.999,19.75-5,35.75-0.013" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 1" id="size-intitial-and-terminal2">
+<span class="pre-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<circle cx="12" cy="32.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="47.75" cy="32" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="47.75" cy="32" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M12,32.012c0,0,18.75,0,35.75-0.012" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<circle cx="12" cy="32.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="47.75" cy="32" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="47.75" cy="32" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M12,32.012c0,0,18.75,0,35.75-0.012" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<circle cx="12" cy="32.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="47.75" cy="32" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="47.75" cy="32" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M12,32.012c0,0,18.75,0,35.75-0.012" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 1" id="size-intitial-and-terminal3">
+<span class="pre-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<circle cx="44.537" cy="44.05" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="17.419" cy="20.755" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="17.419" cy="20.755" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M44.537,44.051c0,0-14.219-12.223-27.119-23.295    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<circle cx="44.537" cy="44.05" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="17.419" cy="20.755" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="17.419" cy="20.755" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M44.537,44.051c0,0-14.219-12.223-27.119-23.295    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<circle cx="44.537" cy="44.05" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="17.419" cy="20.755" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="17.419" cy="20.755" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M44.537,44.051c0,0-14.219-12.223-27.119-23.295    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 3" id="size-alternative-join-combo">
+<span class="pre-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.25C29,31.25,29,31,20,31" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="18.375" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.25C29,31.25,29,31,20,31" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="18.375" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.25C29,31.25,29,31,20,31" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="18.375" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" />
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 3" id="size-alternative-join-combo2">
+<span class="pre-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="3.125" width="3.125" x="15.844" y="19.594" /><circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.25C29,31.25,29,31,20,31" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="18.375" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="3.125" width="3.125" x="15.844" y="19.594" /><circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.25C29,31.25,29,31,20,31" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="18.375" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="3.125" width="3.125" x="15.844" y="19.594" /><circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.25C29,31.25,29,31,20,31" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="18.375" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" />
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 4" id="size-alternative-join-combo3">
+<span class="pre-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="3.125" width="3.125" x="32.262" y="20.292" /><circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.25C29,31.25,29,31,20,31" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="18.375" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="3.125" width="3.125" x="32.262" y="20.292" /><circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.25C29,31.25,29,31,20,31" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="18.375" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="3.125" width="3.125" x="32.262" y="20.292" /><circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.25C29,31.25,29,31,20,31" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="18.375" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" />
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 3" id="size-alternative-join-combo4">
+<span class="pre-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="3.125" width="3.125" x="32.262" y="20.292" /><circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.25C29,31.25,29,31,20,31" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="31" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="3.125" width="3.125" x="32.262" y="20.292" /><circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.25C29,31.25,29,31,20,31" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="31" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="3.125" width="3.125" x="32.262" y="20.292" /><circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.25C29,31.25,29,31,20,31" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="31" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" />
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 4" id="size-alternative-join-combo5">
+<span class="pre-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="3.125" width="3.125" x="32.262" y="20.292" /><rect height="3.125" width="3.125" x="15.844" y="33.438" /><circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.25C29,31.25,29,31,20,31" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="31" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="3.125" width="3.125" x="32.262" y="20.292" /><rect height="3.125" width="3.125" x="15.844" y="33.438" /><circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.25C29,31.25,29,31,20,31" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="31" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="3.125" width="3.125" x="32.262" y="20.292" /><rect height="3.125" width="3.125" x="15.844" y="33.438" /><circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.25C29,31.25,29,31,20,31" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="31" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" />
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 4" id="size-disturbing-selector1">
+<span class="pre-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="3.125" width="3.125" x="32.262" y="20.292" /><rect height="3.125" width="3.125" x="15.844" y="33.438" /><circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.25C29,31.25,29,31,20,31" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="31" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" /><rect fill="none" height="15.5" stroke="#990000" stroke-dasharray="1,2" stroke-miterlimit="10" width="17.125" x="9" y="31" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="3.125" width="3.125" x="32.262" y="20.292" /><rect height="3.125" width="3.125" x="15.844" y="33.438" /><circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.25C29,31.25,29,31,20,31" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="31" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" /><rect fill="none" height="15.5" stroke="#990000" stroke-dasharray="1,2" stroke-miterlimit="10" width="17.125" x="9" y="31" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="3.125" width="3.125" x="32.262" y="20.292" /><rect height="3.125" width="3.125" x="15.844" y="33.438" /><circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.25C29,31.25,29,31,20,31" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="31" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" /><rect fill="none" height="15.5" stroke="#990000" stroke-dasharray="1,2" stroke-miterlimit="10" width="17.125" x="9" y="31" />
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 4" id="size-disturbing-path1">
+<span class="pre-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="3.125" width="3.125" x="32.262" y="20.292" /><rect height="3.125" width="3.125" x="15.844" y="33.438" /><circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.253C29,31.253,29,31.003,20,31.003" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="31" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" /><path d="M1.741,31.003    c2.148,14.152,39.203,62.386,60.122,0" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="3.125" width="3.125" x="32.262" y="20.292" /><rect height="3.125" width="3.125" x="15.844" y="33.438" /><circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.253C29,31.253,29,31.003,20,31.003" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="31" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" /><path d="M1.741,31.003    c2.148,14.152,39.203,62.386,60.122,0" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="3.125" width="3.125" x="32.262" y="20.292" /><rect height="3.125" width="3.125" x="15.844" y="33.438" /><circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.253C29,31.253,29,31.003,20,31.003" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="31" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" /><path d="M1.741,31.003    c2.148,14.152,39.203,62.386,60.122,0" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+</p>
+
+<h3>1.2&nbsp;&nbsp;<a href="test_selectors_genfromSVG.html">Selectors</a></h3>
+
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest selectionset 4,4 #9E005D" id="size-enclose1">
+<span class="pre-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="20" width="28" x="28" y="12" /><rect height="16" width="11" x="45" y="36" /><rect height="40" width="16" x="8" y="12" /><rect fill="none" height="56" stroke="#E8ACAC" stroke-dasharray="1,2" stroke-miterlimit="10" width="36" x="4" y="4" /><g>
+			<g>
+				<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="12" x2="9.108887" y1="2" y2="2.722656" />
+				<g>
+					<polygon points="10.629883,0.595215 9.395508,2.650879 11.452148,3.884277 10.055664,4.233398 8,3 9.233398,0.944336      " />
+				</g>
+			</g>
+		</g>
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="20" width="28" x="28" y="12" /><rect height="16" width="11" x="45" y="36" /><rect fill="#9E005D" height="40" width="16" x="8" y="12" /><rect fill="none" height="56" stroke="#E8ACAC" stroke-dasharray="1,2" stroke-miterlimit="10" width="36" x="4" y="4" /><g>
+			<g>
+				<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="12" x2="9.108887" y1="2" y2="2.722656" />
+				<g>
+					<polygon points="10.629883,0.595215 9.395508,2.650879 11.452148,3.884277 10.055664,4.233398 8,3 9.233398,0.944336      " />
+				</g>
+			</g>
+		</g>
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="20" width="28" x="28" y="12" /><rect height="16" width="11" x="45" y="36" /><rect height="40" width="16" x="8" y="12" /><rect fill="none" height="56" stroke="#E8ACAC" stroke-dasharray="1,2" stroke-miterlimit="10" width="36" x="4" y="4" /><g>
+			<g>
+				<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="12" x2="9.108887" y1="2" y2="2.722656" />
+				<g>
+					<polygon points="10.629883,0.595215 9.395508,2.650879 11.452148,3.884277 10.055664,4.233398 8,3 9.233398,0.944336      " />
+				</g>
+			</g>
+		</g>
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest selectionset 4,4 #9E005D" id="size-enclose2">
+<span class="pre-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="20" width="28" x="28" y="12" /><rect height="16" width="11" x="45" y="36" /><rect height="40" width="16" x="8" y="12" /><rect fill="none" height="56" stroke="#E8ACAC" stroke-dasharray="1,2" stroke-miterlimit="10" width="40" x="20" y="4" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="1,1" stroke-miterlimit="10" x1="4" x2="20" y1="4" y2="60" /><g>
+			<g>
+				<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="12" x2="9.108887" y1="2" y2="2.722656" />
+				<g>
+					<polygon points="10.629883,0.595215 9.395508,2.650879 11.452148,3.884277 10.055664,4.233398 8,3 9.233398,0.944336      " />
+				</g>
+			</g>
+		</g>
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect fill="#9E005D" height="20" width="28" x="28" y="12" /><rect fill="#9E005D" height="16" width="11" x="45" y="36" /><rect height="40" width="16" x="8" y="12" /><rect fill="none" height="56" stroke="#E8ACAC" stroke-dasharray="1,2" stroke-miterlimit="10" width="40" x="20" y="4" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="1,1" stroke-miterlimit="10" x1="4" x2="20" y1="4" y2="60" /><g>
+			<g>
+				<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="12" x2="9.108887" y1="2" y2="2.722656" />
+				<g>
+					<polygon points="10.629883,0.595215 9.395508,2.650879 11.452148,3.884277 10.055664,4.233398 8,3 9.233398,0.944336      " />
+				</g>
+			</g>
+		</g>
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="20" width="28" x="28" y="12" /><rect height="16" width="11" x="45" y="36" /><rect height="40" width="16" x="8" y="12" /><rect fill="none" height="56" stroke="#E8ACAC" stroke-dasharray="1,2" stroke-miterlimit="10" width="40" x="20" y="4" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="1,1" stroke-miterlimit="10" x1="4" x2="20" y1="4" y2="60" /><g>
+			<g>
+				<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="12" x2="9.108887" y1="2" y2="2.722656" />
+				<g>
+					<polygon points="10.629883,0.595215 9.395508,2.650879 11.452148,3.884277 10.055664,4.233398 8,3 9.233398,0.944336      " />
+				</g>
+			</g>
+		</g>
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest selectionset 4,4 #9E005D" id="size-intersect1">
+<span class="pre-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="20" width="28" x="28" y="12" /><rect height="16" width="11" x="45" y="36" /><rect height="40" width="16" x="8" y="12" /><rect fill="none" height="56" stroke="#E8ACAC" stroke-dasharray="3,1" stroke-miterlimit="10" width="36" x="4" y="4" /><g>
+			<g>
+				<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="12" x2="9.108887" y1="2" y2="2.722656" />
+				<g>
+					<polygon points="10.629883,0.595215 9.395508,2.650879 11.452148,3.884277 10.055664,4.233398 8,3 9.233398,0.944336      " />
+				</g>
+			</g>
+		</g>
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect fill="#9E005D" height="20" width="28" x="28" y="12" /><rect height="16" width="11" x="45" y="36" /><rect fill="#9E005D" height="40" width="16" x="8" y="12" /><rect fill="none" height="56" stroke="#E8ACAC" stroke-dasharray="3,1" stroke-miterlimit="10" width="36" x="4" y="4" /><g>
+			<g>
+				<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="12" x2="9.108887" y1="2" y2="2.722656" />
+				<g>
+					<polygon points="10.629883,0.595215 9.395508,2.650879 11.452148,3.884277 10.055664,4.233398 8,3 9.233398,0.944336      " />
+				</g>
+			</g>
+		</g>
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="20" width="28" x="28" y="12" /><rect height="16" width="11" x="45" y="36" /><rect height="40" width="16" x="8" y="12" /><rect fill="none" height="56" stroke="#E8ACAC" stroke-dasharray="3,1" stroke-miterlimit="10" width="36" x="4" y="4" /><g>
+			<g>
+				<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="12" x2="9.108887" y1="2" y2="2.722656" />
+				<g>
+					<polygon points="10.629883,0.595215 9.395508,2.650879 11.452148,3.884277 10.055664,4.233398 8,3 9.233398,0.944336      " />
+				</g>
+			</g>
+		</g>
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest selectionset 4,4 #9E005D" id="size-intersect2">
+<span class="pre-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="20" width="28" x="28" y="12" /><rect height="16" width="11" x="45" y="36" /><rect height="40" width="16" x="8" y="12" /><rect fill="none" height="56" stroke="#E8ACAC" stroke-dasharray="3,1" stroke-miterlimit="10" width="24" x="36" y="4" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="1,1" stroke-miterlimit="10" x1="4" x2="36" y1="4" y2="60" /><g>
+			<g>
+				<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="12" x2="9.108887" y1="2" y2="2.722656" />
+				<g>
+					<polygon points="10.629883,0.595215 9.395508,2.650879 11.452148,3.884277 10.055664,4.233398 8,3 9.233398,0.944336      " />
+				</g>
+			</g>
+		</g>
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect fill="#9E005D" height="20" width="28" x="28" y="12" /><rect fill="#9E005D" height="16" width="11" x="45" y="36" /><rect height="40" width="16" x="8" y="12" /><rect fill="none" height="56" stroke="#E8ACAC" stroke-dasharray="3,1" stroke-miterlimit="10" width="24" x="36" y="4" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="1,1" stroke-miterlimit="10" x1="4" x2="36" y1="4" y2="60" /><g>
+			<g>
+				<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="12" x2="9.108887" y1="2" y2="2.722656" />
+				<g>
+					<polygon points="10.629883,0.595215 9.395508,2.650879 11.452148,3.884277 10.055664,4.233398 8,3 9.233398,0.944336      " />
+				</g>
+			</g>
+		</g>
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="20" width="28" x="28" y="12" /><rect height="16" width="11" x="45" y="36" /><rect height="40" width="16" x="8" y="12" /><rect fill="none" height="56" stroke="#E8ACAC" stroke-dasharray="3,1" stroke-miterlimit="10" width="24" x="36" y="4" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="1,1" stroke-miterlimit="10" x1="4" x2="36" y1="4" y2="60" /><g>
+			<g>
+				<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="12" x2="9.108887" y1="2" y2="2.722656" />
+				<g>
+					<polygon points="10.629883,0.595215 9.395508,2.650879 11.452148,3.884277 10.055664,4.233398 8,3 9.233398,0.944336      " />
+				</g>
+			</g>
+		</g>
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest selectionset 4,4 #9E005D" id="size-intersect3">
+<span class="pre-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="20" width="28" x="28" y="12" /><rect height="16" width="11" x="45" y="36" /><rect height="40" width="16" x="8" y="12" /><rect fill="none" height="56" stroke="#E8ACAC" stroke-dasharray="3,1" stroke-miterlimit="10" width="24" x="36" y="4" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="0.866025,0.866025" stroke-miterlimit="10" stroke-width="0.866025" x1="36" x2="4" y1="60" y2="4" /><g>
+			<g>
+				<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="12" x2="9.108887" y1="2" y2="2.722656" />
+				<g>
+					<polygon points="10.629883,0.595215 9.395508,2.650879 11.452148,3.884277 10.055664,4.233398 8,3 9.233398,0.944336      " />
+				</g>
+			</g>
+		</g>
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect fill="#9E005D" height="20" width="28" x="28" y="12" /><rect fill="#9E005D" height="16" width="11" x="45" y="36" /><rect height="40" width="16" x="8" y="12" /><rect fill="none" height="56" stroke="#E8ACAC" stroke-dasharray="3,1" stroke-miterlimit="10" width="24" x="36" y="4" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="0.866025,0.866025" stroke-miterlimit="10" stroke-width="0.866025" x1="36" x2="4" y1="60" y2="4" /><g>
+			<g>
+				<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="12" x2="9.108887" y1="2" y2="2.722656" />
+				<g>
+					<polygon points="10.629883,0.595215 9.395508,2.650879 11.452148,3.884277 10.055664,4.233398 8,3 9.233398,0.944336      " />
+				</g>
+			</g>
+		</g>
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="20" width="28" x="28" y="12" /><rect height="16" width="11" x="45" y="36" /><rect height="40" width="16" x="8" y="12" /><rect fill="none" height="56" stroke="#E8ACAC" stroke-dasharray="3,1" stroke-miterlimit="10" width="24" x="36" y="4" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="0.866025,0.866025" stroke-miterlimit="10" stroke-width="0.866025" x1="36" x2="4" y1="60" y2="4" /><g>
+			<g>
+				<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="12" x2="9.108887" y1="2" y2="2.722656" />
+				<g>
+					<polygon points="10.629883,0.595215 9.395508,2.650879 11.452148,3.884277 10.055664,4.233398 8,3 9.233398,0.944336      " />
+				</g>
+			</g>
+		</g>
+</svg>
+</span>
+</p>
+
+<h3>1.3&nbsp;&nbsp;<a href="test_combine-instructions_genfromSVG.html">Combining Instructions</a></h3>
+
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 3" id="size-two-moves1">
+<span class="pre-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="8" width="8" x="10" y="28" /><rect height="8" width="8" x="26" y="28" /><circle cx="36" cy="36" fill="none" r="2.5" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><line fill="none" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="36" x2="36" y1="24" y2="36" /><circle cx="20" cy="40" fill="none" r="2.5" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><line fill="none" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="20" x2="20" y1="24" y2="40" /><path d="M4,24.06c3.566,9.999,10.148-5,16-0.013" fill="none" stroke="#9ACDCD" stroke-miterlimit="10" stroke-width="0.5" /><path d="M20,24.06c3.565,9.998,10.149-4.999,16-0.013" fill="none" stroke="#9ACDCD" stroke-miterlimit="10" stroke-width="0.5" /><path d="M36,24.06c3.565,9.999,10.148-5,16-0.013" fill="none" stroke="#9ACDCD" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="52" cy="24" fill="#9ACDCD" r="1" stroke="#9ACDCD" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="52" cy="24" fill="none" r="2" stroke="#9ACDCD" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="none" height="37" stroke="#E5B7B7" stroke-dasharray="1,2" stroke-miterlimit="10" width="12" x="8" y="24" /><circle cx="4" cy="24" fill="#9ACDCD" r="1" stroke="#9ACDCD" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="none" height="37" stroke="#E5B7B7" stroke-dasharray="1,2" stroke-miterlimit="10" width="12" x="24" y="24" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="8" width="8" x="10" y="44" /><rect height="8" width="8" x="26" y="40" /><circle cx="36" cy="36" fill="none" r="2.5" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><line fill="none" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="36" x2="36" y1="24" y2="36" /><circle cx="20" cy="40" fill="none" r="2.5" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><line fill="none" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="20" x2="20" y1="24" y2="40" /><path d="M4,24.06c3.566,9.999,10.148-5,16-0.013" fill="none" stroke="#9ACDCD" stroke-miterlimit="10" stroke-width="0.5" /><path d="M20,24.06c3.565,9.998,10.149-4.999,16-0.013" fill="none" stroke="#9ACDCD" stroke-miterlimit="10" stroke-width="0.5" /><path d="M36,24.06c3.565,9.999,10.148-5,16-0.013" fill="none" stroke="#9ACDCD" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="52" cy="24" fill="#9ACDCD" r="1" stroke="#9ACDCD" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="52" cy="24" fill="none" r="2" stroke="#9ACDCD" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="none" height="37" stroke="#E5B7B7" stroke-dasharray="1,2" stroke-miterlimit="10" width="12" x="8" y="24" /><circle cx="4" cy="24" fill="#9ACDCD" r="1" stroke="#9ACDCD" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="none" height="37" stroke="#E5B7B7" stroke-dasharray="1,2" stroke-miterlimit="10" width="12" x="24" y="24" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="8" width="8" x="10" y="28" /><rect height="8" width="8" x="26" y="28" /><circle cx="36" cy="36" fill="none" r="2.5" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><line fill="none" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="36" x2="36" y1="24" y2="36" /><circle cx="20" cy="40" fill="none" r="2.5" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><line fill="none" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="20" x2="20" y1="24" y2="40" /><path d="M4,24.06c3.566,9.999,10.148-5,16-0.013" fill="none" stroke="#9ACDCD" stroke-miterlimit="10" stroke-width="0.5" /><path d="M20,24.06c3.565,9.998,10.149-4.999,16-0.013" fill="none" stroke="#9ACDCD" stroke-miterlimit="10" stroke-width="0.5" /><path d="M36,24.06c3.565,9.999,10.148-5,16-0.013" fill="none" stroke="#9ACDCD" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="52" cy="24" fill="#9ACDCD" r="1" stroke="#9ACDCD" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="52" cy="24" fill="none" r="2" stroke="#9ACDCD" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="none" height="37" stroke="#E5B7B7" stroke-dasharray="1,2" stroke-miterlimit="10" width="12" x="8" y="24" /><circle cx="4" cy="24" fill="#9ACDCD" r="1" stroke="#9ACDCD" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="none" height="37" stroke="#E5B7B7" stroke-dasharray="1,2" stroke-miterlimit="10" width="12" x="24" y="24" />
+</svg>
+</span>
+</p>
+
+<h3>2.1&nbsp;&nbsp;<a href="test_alignrel_genfromSVG.html">Align relative</a></h3>
+
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 2" id="size-align-rel-right">
+<span class="pre-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="16" width="8" x="12" y="12" /><rect height="8" width="12" x="24" y="44" /><rect height="12" width="12" x="40" y="28" /><rect fill="none" height="46" stroke="#E5B7B7" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="60" x2="60" y1="10" y2="39" /><polyline fill="none" points="    57,12 60,10 57,8   " stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M60,10c0,0,5.367-3.318,0-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,56,1,56,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="16" width="8" x="44" y="12" /><rect height="8" width="12" x="40" y="44" /><rect height="12" width="12" x="40" y="28" /><rect fill="none" height="46" stroke="#E5B7B7" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="60" x2="60" y1="10" y2="39" /><polyline fill="none" points="    57,12 60,10 57,8   " stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M60,10c0,0,5.367-3.318,0-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,56,1,56,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="16" width="8" x="12" y="12" /><rect height="8" width="12" x="24" y="44" /><rect height="12" width="12" x="40" y="28" /><rect fill="none" height="46" stroke="#E5B7B7" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="60" x2="60" y1="10" y2="39" /><polyline fill="none" points="    57,12 60,10 57,8   " stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M60,10c0,0,5.367-3.318,0-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,56,1,56,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 2" id="size-align-rel-left">
+<span class="pre-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="16" width="8" x="12" y="12" /><rect height="8" width="12" x="24" y="44" /><rect height="12" width="12" x="40" y="28" /><rect fill="none" height="46" stroke="#E5B7B7" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="8" x2="8" y1="10" y2="39" /><polyline fill="none" points="    11,12 8,10 11,8   " stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M8,10c0,0,52,0,52-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,4,0,4,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="16" width="8" x="12" y="12" /><rect height="8" width="12" x="12" y="44" /><rect height="12" width="12" x="12" y="28" /><rect fill="none" height="46" stroke="#E5B7B7" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="8" x2="8" y1="10" y2="39" /><polyline fill="none" points="    11,12 8,10 11,8   " stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M8,10c0,0,52,0,52-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,4,0,4,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="16" width="8" x="12" y="12" /><rect height="8" width="12" x="24" y="44" /><rect height="12" width="12" x="40" y="28" /><rect fill="none" height="46" stroke="#E5B7B7" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="8" x2="8" y1="10" y2="39" /><polyline fill="none" points="    11,12 8,10 11,8   " stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M8,10c0,0,52,0,52-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,4,0,4,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 2" id="size-align-rel-bottom">
+<span class="pre-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="16" width="8" x="12" y="12" /><rect height="8" width="12" x="24" y="44" /><rect height="12" width="12" x="40" y="28" /><rect fill="none" height="46" stroke="#E5B7B7" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><line fill="none" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="8" x2="33" y1="56" y2="56" /><polyline fill="none" points="    10,53 8,56 6,53   " stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><path d="M8,56c15-1,52-28.653,52-52" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c3,3-1,31,4,52" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="16" width="8" x="12" y="36" /><rect height="8" width="12" x="24" y="44" /><rect height="12" width="12" x="40" y="40" /><rect fill="none" height="46" stroke="#E5B7B7" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><line fill="none" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="8" x2="33" y1="56" y2="56" /><polyline fill="none" points="    10,53 8,56 6,53   " stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><path d="M8,56c15-1,52-28.653,52-52" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c3,3-1,31,4,52" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="16" width="8" x="12" y="12" /><rect height="8" width="12" x="24" y="44" /><rect height="12" width="12" x="40" y="28" /><rect fill="none" height="46" stroke="#E5B7B7" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><line fill="none" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="8" x2="33" y1="56" y2="56" /><polyline fill="none" points="    10,53 8,56 6,53   " stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><path d="M8,56c15-1,52-28.653,52-52" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c3,3-1,31,4,52" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 2" id="size-align-rel-top">
+<span class="pre-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="16" width="8" x="12" y="12" /><rect height="8" width="12" x="24" y="44" /><rect height="12" width="12" x="40" y="28" /><rect fill="none" height="46" stroke="#E5B7B7" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="8" x2="33" y1="10" y2="10" /><polyline fill="none" points="    10,13 8,10 6,13   " stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M6,5" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M8,10c0,0,52,0,52-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,4,0,4,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="16" width="8" x="12" y="12" /><rect height="8" width="12" x="24" y="12" /><rect height="12" width="12" x="40" y="12" /><rect fill="none" height="46" stroke="#E5B7B7" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="8" x2="33" y1="10" y2="10" /><polyline fill="none" points="    10,13 8,10 6,13   " stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M6,5" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M8,10c0,0,52,0,52-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,4,0,4,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="16" width="8" x="12" y="12" /><rect height="8" width="12" x="24" y="44" /><rect height="12" width="12" x="40" y="28" /><rect fill="none" height="46" stroke="#E5B7B7" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="8" x2="33" y1="10" y2="10" /><polyline fill="none" points="    10,13 8,10 6,13   " stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M6,5" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M8,10c0,0,52,0,52-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,4,0,4,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+</p>
+
+<h3>2.2&nbsp;&nbsp;<a href="test_alignabs_genfromSVG.html">Align absolute</a></h3>
+
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 2" id="size-align-abs-right">
+<span class="pre-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="16" width="8" x="12" y="12" /><rect height="8" width="12" x="24" y="44" /><rect height="12" width="12" x="40" y="28" /><rect fill="none" height="46" stroke="#FF8888" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="60" x2="60" y1="10" y2="60" /><polyline fill="none" points="    57,12 60,10 57,8   " stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M60,10c0,0,5.367-3.318,0-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,56,1,56,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="#FF8888" height="5" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" width="5" x="55" y="55" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="16" width="8" x="52" y="12" /><rect height="8" width="12" x="48" y="44" /><rect height="12" width="12" x="48" y="28" /><rect fill="none" height="46" stroke="#FF8888" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="60" x2="60" y1="10" y2="60" /><polyline fill="none" points="    57,12 60,10 57,8   " stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M60,10c0,0,5.367-3.318,0-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,56,1,56,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="#FF8888" height="5" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" width="5" x="55" y="55" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="16" width="8" x="12" y="12" /><rect height="8" width="12" x="24" y="44" /><rect height="12" width="12" x="40" y="28" /><rect fill="none" height="46" stroke="#FF8888" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="60" x2="60" y1="10" y2="60" /><polyline fill="none" points="    57,12 60,10 57,8   " stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M60,10c0,0,5.367-3.318,0-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,56,1,56,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="#FF8888" height="5" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" width="5" x="55" y="55" />
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 2" id="size-align-abs-left">
+<span class="pre-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="16" width="8" x="12" y="12" /><rect height="8" width="12" x="24" y="44" /><rect height="12" width="12" x="40" y="28" /><rect fill="none" height="46" stroke="#FF8888" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="8" x2="8" y1="10" y2="60" /><polyline fill="none" points="    11,12 8,10 11,8   " stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M8,10c0,0,52,0,52-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,4,0,4,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="#FF8888" height="5" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" width="5" x="8" y="55" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="16" width="8" x="8" y="12" /><rect height="8" width="12" x="8" y="44" /><rect height="12" width="12" x="8" y="28" /><rect fill="none" height="46" stroke="#FF8888" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="8" x2="8" y1="10" y2="60" /><polyline fill="none" points="    11,12 8,10 11,8   " stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M8,10c0,0,52,0,52-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,4,0,4,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="#FF8888" height="5" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" width="5" x="8" y="55" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="16" width="8" x="12" y="12" /><rect height="8" width="12" x="24" y="44" /><rect height="12" width="12" x="40" y="28" /><rect fill="none" height="46" stroke="#FF8888" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="8" x2="8" y1="10" y2="60" /><polyline fill="none" points="    11,12 8,10 11,8   " stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M8,10c0,0,52,0,52-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,4,0,4,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="#FF8888" height="5" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" width="5" x="8" y="55" />
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 2" id="size-align-abs-bottom">
+<span class="pre-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="16" width="8" x="12" y="12" /><rect height="8" width="12" x="24" y="44" /><rect height="12" width="12" x="40" y="28" /><rect fill="none" height="46" stroke="#FF8888" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="8" x2="62" y1="56" y2="56" /><polyline fill="none" points="    10,53 8,56 6,53   " stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><path d="M8,56c15-1,52-28.653,52-52" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c3,3-1,31,4,52" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="#FF8888" height="5" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" width="5" x="57" y="51" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="16" width="8" x="12" y="40" /><rect height="8" width="12" x="24" y="48" /><rect height="12" width="12" x="40" y="44" /><rect fill="none" height="46" stroke="#FF8888" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="8" x2="62" y1="56" y2="56" /><polyline fill="none" points="    10,53 8,56 6,53   " stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><path d="M8,56c15-1,52-28.653,52-52" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c3,3-1,31,4,52" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="#FF8888" height="5" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" width="5" x="57" y="51" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="16" width="8" x="12" y="12" /><rect height="8" width="12" x="24" y="44" /><rect height="12" width="12" x="40" y="28" /><rect fill="none" height="46" stroke="#FF8888" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="8" x2="62" y1="56" y2="56" /><polyline fill="none" points="    10,53 8,56 6,53   " stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><path d="M8,56c15-1,52-28.653,52-52" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c3,3-1,31,4,52" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="#FF8888" height="5" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" width="5" x="57" y="51" />
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 2" id="size-align-abs-top">
+<span class="pre-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="16" width="8" x="12" y="12" /><rect height="8" width="12" x="24" y="44" /><rect height="12" width="12" x="40" y="28" /><rect fill="none" height="46" stroke="#FF8888" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="8" x2="61" y1="10" y2="10" /><polyline fill="none" points="    10,13 8,10 6,13   " stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M6,5" fill="#990000" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M8,10c0,0,52,0,52-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,4,0,4,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="#FF8888" height="5" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" width="5" x="56" y="10" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="16" width="8" x="12" y="10" /><rect height="8" width="12" x="24" y="10" /><rect height="12" width="12" x="40" y="10" /><rect fill="none" height="46" stroke="#FF8888" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="8" x2="61" y1="10" y2="10" /><polyline fill="none" points="    10,13 8,10 6,13   " stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M6,5" fill="#990000" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M8,10c0,0,52,0,52-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,4,0,4,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="#FF8888" height="5" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" width="5" x="56" y="10" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="16" width="8" x="12" y="12" /><rect height="8" width="12" x="24" y="44" /><rect height="12" width="12" x="40" y="28" /><rect fill="none" height="46" stroke="#FF8888" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="8" x2="61" y1="10" y2="10" /><polyline fill="none" points="    10,13 8,10 6,13   " stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M6,5" fill="#990000" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M8,10c0,0,52,0,52-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,4,0,4,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="#FF8888" height="5" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" width="5" x="56" y="10" />
+</svg>
+</span>
+</p>
+
+<h3>2.3&nbsp;&nbsp;<a href="test_moverel_genfromSVG.html">Move by vector (relative)</a></h3>
+
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 2" id="size-move-rel-v-down">
+<span class="pre-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="16" width="8" x="6" y="12" /><rect height="8" width="12" x="22" y="12" /><rect height="12" width="12" x="37" y="17" /><rect fill="none" height="46" stroke="#FF8888" stroke-dasharray="1,2" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="60" x2="60" y1="10" y2="43" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M60,10c0,0,5.367-3.318,0-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,56,1,56,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="43" fill="none" r="2.281" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="16" width="8" x="6" y="12" /><rect height="8" width="12" x="22" y="45" /><rect height="12" width="12" x="37" y="50" /><rect fill="none" height="46" stroke="#FF8888" stroke-dasharray="1,2" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="60" x2="60" y1="10" y2="43" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M60,10c0,0,5.367-3.318,0-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,56,1,56,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="43" fill="none" r="2.281" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="16" width="8" x="6" y="12" /><rect height="8" width="12" x="22" y="12" /><rect height="12" width="12" x="37" y="17" /><rect fill="none" height="46" stroke="#FF8888" stroke-dasharray="1,2" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="60" x2="60" y1="10" y2="43" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M60,10c0,0,5.367-3.318,0-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,56,1,56,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="43" fill="none" r="2.281" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" />
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 2" id="size-move-rel-dl">
+<span class="pre-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="8" width="12" x="22" y="12" /><rect height="12" width="12" x="37" y="17" /><rect fill="none" height="46" stroke="#FF8888" stroke-dasharray="1,2" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="60" x2="41" y1="10" y2="20" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M60,10c0,0,5.367-3.318,0-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,56,1,56,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="41" cy="20" fill="none" r="2.281" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="8" width="12" x="3" y="22" /><rect height="12" width="12" x="18" y="27" /><rect fill="none" height="46" stroke="#FF8888" stroke-dasharray="1,2" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="60" x2="41" y1="10" y2="20" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M60,10c0,0,5.367-3.318,0-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,56,1,56,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="41" cy="20" fill="none" r="2.281" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="8" width="12" x="22" y="12" /><rect height="12" width="12" x="37" y="17" /><rect fill="none" height="46" stroke="#FF8888" stroke-dasharray="1,2" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="60" x2="41" y1="10" y2="20" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M60,10c0,0,5.367-3.318,0-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,56,1,56,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="41" cy="20" fill="none" r="2.281" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" />
+</svg>
+</span>
+</p>
+
+<h3>2.4&nbsp;&nbsp;<a href="test_moveabs_genfromSVG.html">Move to location (absolute)</a></h3>
+
+
+<h3>2.5&nbsp;&nbsp;<a href="test_create+destroy_genfromSVG.html">Create and destroy</a></h3>
+
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 2" id="size-clone1">
+<span class="pre-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="32" stroke="#FFFFFF" stroke-miterlimit="10" width="22" x="21" y="19" /><circle cx="4" cy="4.012207" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M36,8c1-5,14-4,24-4" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c29,0,31-2,32,4" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="36" x2="40" y1="8" y2="16" /><rect fill="none" height="1" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" width="5" x="36" y="8" /><rect fill="none" height="1" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" width="5" x="40" y="16" /><rect fill="none" height="16" stroke="#FF8888" stroke-dasharray="3,1" stroke-miterlimit="10" width="8" x="28" y="8" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="32" stroke="#FFFFFF" stroke-miterlimit="10" width="22" x="21" y="19" /><rect height="32" stroke="#FFFFFF" stroke-miterlimit="10" width="22" x="25" y="27" /><circle cx="4" cy="4.012207" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M36,8c1-5,14-4,24-4" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c29,0,31-2,32,4" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="36" x2="40" y1="8" y2="16" /><rect fill="none" height="1" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" width="5" x="36" y="8" /><rect fill="none" height="1" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" width="5" x="40" y="16" /><rect fill="none" height="16" stroke="#FF8888" stroke-dasharray="3,1" stroke-miterlimit="10" width="8" x="28" y="8" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="32" stroke="#FFFFFF" stroke-miterlimit="10" width="22" x="21" y="19" /><circle cx="4" cy="4.012207" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M36,8c1-5,14-4,24-4" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c29,0,31-2,32,4" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="36" x2="40" y1="8" y2="16" /><rect fill="none" height="1" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" width="5" x="36" y="8" /><rect fill="none" height="1" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" width="5" x="40" y="16" /><rect fill="none" height="16" stroke="#FF8888" stroke-dasharray="3,1" stroke-miterlimit="10" width="8" x="28" y="8" />
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 2" id="size-cut-horiz">
+<span class="pre-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="32" stroke="#FFFFFF" stroke-miterlimit="10" width="22" x="30" y="12" /><rect height="40" stroke="#FFFFFF" stroke-miterlimit="10" width="22" x="2" y="12" /><rect height="12" stroke="#FFFFFF" stroke-miterlimit="10" width="12" x="32" y="48" /><circle cx="4" cy="4.012207" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M56,34c2-2,9-20.625,4-30" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c53-2,54-2,52,30" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><line fill="none" stroke="#FF8888" stroke-dasharray="6,3" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="56" x2="17" y1="34" y2="34" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="22" stroke="#FFFFFF" stroke-miterlimit="10" width="22" x="30" y="12" /><rect height="10" stroke="#FFFFFF" stroke-miterlimit="10" width="22" x="30" y="34" /><rect height="40" stroke="#FFFFFF" stroke-miterlimit="10" width="22" x="2" y="12" /><rect height="12" stroke="#FFFFFF" stroke-miterlimit="10" width="12" x="32" y="48" /><circle cx="4" cy="4.012207" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M56,34c2-2,9-20.625,4-30" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c53-2,54-2,52,30" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><line fill="none" stroke="#FF8888" stroke-dasharray="6,3" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="56" x2="17" y1="34" y2="34" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="32" stroke="#FFFFFF" stroke-miterlimit="10" width="22" x="30" y="12" /><rect height="40" stroke="#FFFFFF" stroke-miterlimit="10" width="22" x="2" y="12" /><rect height="12" stroke="#FFFFFF" stroke-miterlimit="10" width="12" x="32" y="48" /><circle cx="4" cy="4.012207" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M56,34c2-2,9-20.625,4-30" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c53-2,54-2,52,30" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><line fill="none" stroke="#FF8888" stroke-dasharray="6,3" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="56" x2="17" y1="34" y2="34" />
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 2" id="size-delete1">
+<span class="pre-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="40" stroke="#A0A0A0" stroke-miterlimit="10" width="22" x="2" y="12" /><rect height="12" stroke="#A0A0A0" stroke-miterlimit="10" width="12" x="32" y="48" /><rect height="32" stroke="#A0A0A0" stroke-miterlimit="10" width="22" x="30" y="12" /><circle cx="4" cy="4.012207" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M27,8c0-4,25-4,33-4" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c11,0,23,0,23,4" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="6,3" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="55" x2="27" y1="52" y2="8" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="6,3" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="27" x2="55" y1="52" y2="8" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="40" stroke="#A0A0A0" stroke-miterlimit="10" width="22" x="2" y="12" /><circle cx="4" cy="4.012207" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M27,8c0-4,25-4,33-4" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c11,0,23,0,23,4" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="6,3" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="55" x2="27" y1="52" y2="8" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="6,3" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="27" x2="55" y1="52" y2="8" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="40" stroke="#A0A0A0" stroke-miterlimit="10" width="22" x="2" y="12" /><rect height="12" stroke="#A0A0A0" stroke-miterlimit="10" width="12" x="32" y="48" /><rect height="32" stroke="#A0A0A0" stroke-miterlimit="10" width="22" x="30" y="12" /><circle cx="4" cy="4.012207" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M27,8c0-4,25-4,33-4" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c11,0,23,0,23,4" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="6,3" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="55" x2="27" y1="52" y2="8" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="6,3" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="27" x2="55" y1="52" y2="8" />
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 2" id="size-delete2">
+<span class="pre-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="40" stroke="#A0A0A0" stroke-miterlimit="10" width="22" x="2" y="12" /><rect height="12" stroke="#A0A0A0" stroke-miterlimit="10" width="12" x="32" y="48" /><rect height="32" stroke="#A0A0A0" stroke-miterlimit="10" width="22" x="30" y="12" /><circle cx="4" cy="4.012207" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M27,8c0-4,25-4,33-4" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c11,0,23,0,23,4" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="1,5" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="55" x2="27" y1="52" y2="8" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="1,5" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="27" x2="55" y1="52" y2="8" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="40" stroke="#A0A0A0" stroke-miterlimit="10" width="22" x="2" y="12" /><rect height="12" stroke="#A0A0A0" stroke-miterlimit="10" width="12" x="32" y="48" /><circle cx="4" cy="4.012207" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M27,8c0-4,25-4,33-4" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c11,0,23,0,23,4" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="1,5" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="55" x2="27" y1="52" y2="8" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="1,5" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="27" x2="55" y1="52" y2="8" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="40" stroke="#A0A0A0" stroke-miterlimit="10" width="22" x="2" y="12" /><rect height="12" stroke="#A0A0A0" stroke-miterlimit="10" width="12" x="32" y="48" /><rect height="32" stroke="#A0A0A0" stroke-miterlimit="10" width="22" x="30" y="12" /><circle cx="4" cy="4.012207" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M27,8c0-4,25-4,33-4" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c11,0,23,0,23,4" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="1,5" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="55" x2="27" y1="52" y2="8" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="1,5" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="27" x2="55" y1="52" y2="8" />
+</svg>
+</span>
+</p>
+
+<h3>3.1&nbsp;&nbsp;<a href="test_scale+resize_genfromSVG.html">Scale and resize</a></h3>
+
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 2" id="size-shrink-upper">
+<span class="pre-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="7" width="4" x="14" y="30" /><rect height="3" width="10" x="23" y="31" /><rect height="10" width="6" x="38" y="26" /><rect height="7" width="1" x="49" y="37" /><circle cx="59.896" cy="7.988" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="59.896" cy="7.988" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="4" cy="8" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M12,24C26,24,38.898,8,59.896,7.988" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4.103,8.013C4,13,3,31,12,24" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="none" height="22" stroke="#E8ACAC" stroke-dasharray="2,4" stroke-miterlimit="10" width="40" x="12" y="24" /><line fill="none" stroke="#E8ACAC" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="12" x2="12" y1="19" y2="24" /><polyline fill="none" points="    10,21 12,24 14,21   " stroke="#E8ACAC" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="0 0 64 64" width="164" height="164">
+<rect height="2" width="4" x="14" y="35" /><rect height="2" width="10" x="23" y="34" /><rect height="5" width="6" x="38" y="31" /><rect height="2" width="1" x="49" y="42" /><circle cx="59.896" cy="7.988" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="59.896" cy="7.988" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="4" cy="8" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M12,24C26,24,38.898,8,59.896,7.988" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4.103,8.013C4,13,3,31,12,24" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="none" height="22" stroke="#E8ACAC" stroke-dasharray="2,4" stroke-miterlimit="10" width="40" x="12" y="24" /><line fill="none" stroke="#E8ACAC" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="12" x2="12" y1="19" y2="24" /><polyline fill="none" points="    10,21 12,24 14,21   " stroke="#E8ACAC" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="0 0 64 64" width="164" height="164">
 <rect height="7" width="4" x="14" y="30" /><rect height="3" width="10" x="23" y="31" /><rect height="10" width="6" x="38" y="26" /><rect height="7" width="1" x="49" y="37" /><circle cx="59.896" cy="7.988" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="59.896" cy="7.988" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="4" cy="8" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M12,24C26,24,38.898,8,59.896,7.988" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4.103,8.013C4,13,3,31,12,24" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="none" height="22" stroke="#E8ACAC" stroke-dasharray="2,4" stroke-miterlimit="10" width="40" x="12" y="24" /><line fill="none" stroke="#E8ACAC" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="12" x2="12" y1="19" y2="24" /><polyline fill="none" points="    10,21 12,24 14,21   " stroke="#E8ACAC" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" />
 </svg>
 </span>

--- a/tests/test-manual_viewbox-and-scale_passing-distorted.html
+++ b/tests/test-manual_viewbox-and-scale_passing-distorted.html
@@ -1,0 +1,809 @@
+
+<!DOCTYPE html>
+<html>
+
+<head>
+<meta charset="utf-8">
+<title>clip8 | viewBox+size Manual Sheet</title>
+
+<link rel="shortcut icon" type="image/png" href="../lib/jasmine/lib/jasmine-2.5.2/jasmine_favicon.png">
+<link rel="stylesheet" href="../lib/jasmine/lib/jasmine-2.5.2/jasmine.css">
+<script src="../lib/jasmine/lib/jasmine-2.5.2/jasmine.js"></script>
+<script src="../lib/jasmine/lib/jasmine-2.5.2/jasmine-html.js"></script>
+<script src="../lib/jasmine/lib/jasmine-2.5.2/boot.js"></script>
+
+<link rel="stylesheet" href="../css/refsheet.css">
+<link rel="stylesheet" href="../css/clip8.css">
+<script src="../js/svgdom.js"></script>
+<script src="../js/svgretrieve.js"></script>
+<script src="../js/paperclip.js"></script>
+<script src="../js/clip8decode.js"></script>
+<script src="../js/clip8.js"></script>
+
+</head>
+
+
+<body>
+<nav>
+
+<div class="chapternavtitle">[manually generated test sheet]</div>
+
+</nav>
+<h1><span class="sndtitle">clip_8&nbsp;|</span>&nbsp;viewBox+size</h1>
+
+<p>If you encounter a failing test in this section, please consider <a href="https://github.com/broesamle/clip_8/issues">filing an issue</a>. It may indicate several things:
+<br>(a) By accident, the test is not in the list of tests that are expected to fail.
+<br>(b) clip_8 has, in principle, the functionality to pass the test. However, the current implementation relies on
+some experimental features not supported by all browsers. Please refer to
+<a href="https://github.com/broesamle/clip_8/issues/9">Issue 9</a> in this respect.
+<br>(c) Functionality is actually really broken and the test fails, for instance, because of recent disruptive changes.
+</p>
+<p>
+Thank you for your contribution!
+</p>
+
+<h3>1.1&nbsp;&nbsp;<a href="test_controlflow_genfromSVG.html">Control flow</a></h3>
+
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 1" id="intitial-and-terminal">
+<span class="pre-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<circle cx="12" cy="32.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="47.75" cy="32" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="47.75" cy="32" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M12,32c9.75,9.999,19.75-5,35.75-0.013" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<circle cx="12" cy="32.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="47.75" cy="32" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="47.75" cy="32" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M12,32c9.75,9.999,19.75-5,35.75-0.013" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<circle cx="12" cy="32.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="47.75" cy="32" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="47.75" cy="32" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M12,32c9.75,9.999,19.75-5,35.75-0.013" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 1" id="intitial-and-terminal2">
+<span class="pre-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<circle cx="12" cy="32.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="47.75" cy="32" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="47.75" cy="32" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M12,32.012c0,0,18.75,0,35.75-0.012" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<circle cx="12" cy="32.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="47.75" cy="32" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="47.75" cy="32" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M12,32.012c0,0,18.75,0,35.75-0.012" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<circle cx="12" cy="32.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="47.75" cy="32" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="47.75" cy="32" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M12,32.012c0,0,18.75,0,35.75-0.012" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 1" id="intitial-and-terminal3">
+<span class="pre-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<circle cx="44.537" cy="44.05" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="17.419" cy="20.755" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="17.419" cy="20.755" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M44.537,44.051c0,0-14.219-12.223-27.119-23.295    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<circle cx="44.537" cy="44.05" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="17.419" cy="20.755" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="17.419" cy="20.755" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M44.537,44.051c0,0-14.219-12.223-27.119-23.295    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<circle cx="44.537" cy="44.05" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="17.419" cy="20.755" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="17.419" cy="20.755" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M44.537,44.051c0,0-14.219-12.223-27.119-23.295    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 3" id="alternative-join-combo">
+<span class="pre-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.25C29,31.25,29,31,20,31" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="18.375" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.25C29,31.25,29,31,20,31" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="18.375" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.25C29,31.25,29,31,20,31" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="18.375" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" />
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 3" id="alternative-join-combo2">
+<span class="pre-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="3.125" width="3.125" x="15.844" y="19.594" /><circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.25C29,31.25,29,31,20,31" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="18.375" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="3.125" width="3.125" x="15.844" y="19.594" /><circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.25C29,31.25,29,31,20,31" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="18.375" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="3.125" width="3.125" x="15.844" y="19.594" /><circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.25C29,31.25,29,31,20,31" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="18.375" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" />
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 4" id="alternative-join-combo3">
+<span class="pre-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="3.125" width="3.125" x="32.262" y="20.292" /><circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.25C29,31.25,29,31,20,31" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="18.375" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="3.125" width="3.125" x="32.262" y="20.292" /><circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.25C29,31.25,29,31,20,31" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="18.375" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="3.125" width="3.125" x="32.262" y="20.292" /><circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.25C29,31.25,29,31,20,31" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="18.375" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" />
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 3" id="alternative-join-combo4">
+<span class="pre-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="3.125" width="3.125" x="32.262" y="20.292" /><circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.25C29,31.25,29,31,20,31" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="31" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="3.125" width="3.125" x="32.262" y="20.292" /><circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.25C29,31.25,29,31,20,31" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="31" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="3.125" width="3.125" x="32.262" y="20.292" /><circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.25C29,31.25,29,31,20,31" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="31" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" />
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 4" id="alternative-join-combo5">
+<span class="pre-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="3.125" width="3.125" x="32.262" y="20.292" /><rect height="3.125" width="3.125" x="15.844" y="33.438" /><circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.25C29,31.25,29,31,20,31" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="31" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="3.125" width="3.125" x="32.262" y="20.292" /><rect height="3.125" width="3.125" x="15.844" y="33.438" /><circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.25C29,31.25,29,31,20,31" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="31" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="3.125" width="3.125" x="32.262" y="20.292" /><rect height="3.125" width="3.125" x="15.844" y="33.438" /><circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.25C29,31.25,29,31,20,31" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="31" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" />
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 4" id="disturbing-selector1">
+<span class="pre-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="3.125" width="3.125" x="32.262" y="20.292" /><rect height="3.125" width="3.125" x="15.844" y="33.438" /><circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.25C29,31.25,29,31,20,31" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="31" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" /><rect fill="none" height="15.5" stroke="#990000" stroke-dasharray="1,2" stroke-miterlimit="10" width="17.125" x="9" y="31" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="3.125" width="3.125" x="32.262" y="20.292" /><rect height="3.125" width="3.125" x="15.844" y="33.438" /><circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.25C29,31.25,29,31,20,31" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="31" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" /><rect fill="none" height="15.5" stroke="#990000" stroke-dasharray="1,2" stroke-miterlimit="10" width="17.125" x="9" y="31" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="3.125" width="3.125" x="32.262" y="20.292" /><rect height="3.125" width="3.125" x="15.844" y="33.438" /><circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.25C29,31.25,29,31,20,31" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="31" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" /><rect fill="none" height="15.5" stroke="#990000" stroke-dasharray="1,2" stroke-miterlimit="10" width="17.125" x="9" y="31" />
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 4" id="disturbing-path1">
+<span class="pre-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="3.125" width="3.125" x="32.262" y="20.292" /><rect height="3.125" width="3.125" x="15.844" y="33.438" /><circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.253C29,31.253,29,31.003,20,31.003" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="31" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" /><path d="M1.741,31.003    c2.148,14.152,39.203,62.386,60.122,0" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="3.125" width="3.125" x="32.262" y="20.292" /><rect height="3.125" width="3.125" x="15.844" y="33.438" /><circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.253C29,31.253,29,31.003,20,31.003" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="31" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" /><path d="M1.741,31.003    c2.148,14.152,39.203,62.386,60.122,0" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="3.125" width="3.125" x="32.262" y="20.292" /><rect height="3.125" width="3.125" x="15.844" y="33.438" /><circle cx="54.25" cy="25.229" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="54.25" cy="25.229" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="49.5" cy="40.938" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="9" cy="27.012" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M18,28c-6,0-9,6-9-1" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M46.25,22.229    C37.563,11.167,25.5,16.063,20,25.001" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M34.417,31.253C29,31.253,29,31.003,20,31.003" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M49.5,40.938    c-0.271-5.391-4.083-6.688-13.083-6.688" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M54.25,25.229c-2.25,0-3.75,0-6,0" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5465" /><path d="M46.25,28.229c-5.418,0-0.833,0.021-9.833,0.021    " fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><polyline fill="none" points="20,25 18,28     20,31   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="6.625" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="14.813" y="31" /><polyline fill="none" points="36.417,28.25     34.417,31.25 36.417,34.25   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><polyline fill="none" points="46.25,22.229     48.25,25.229 46.25,28.229   " stroke="#9BC9C7" stroke-linecap="square" stroke-miterlimit="10" stroke-width="1.5" /><rect fill="none" height="9.875" stroke="#9BC9C7" stroke-dasharray="1,2" stroke-miterlimit="10" width="5.188" x="31.229" y="18.375" /><path d="M1.741,31.003    c2.148,14.152,39.203,62.386,60.122,0" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+</p>
+
+<h3>1.2&nbsp;&nbsp;<a href="test_selectors_genfromSVG.html">Selectors</a></h3>
+
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest selectionset 4,4 #9E005D" id="enclose1">
+<span class="pre-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="20" width="28" x="28" y="12" /><rect height="16" width="11" x="45" y="36" /><rect height="40" width="16" x="8" y="12" /><rect fill="none" height="56" stroke="#E8ACAC" stroke-dasharray="1,2" stroke-miterlimit="10" width="36" x="4" y="4" /><g>
+			<g>
+				<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="12" x2="9.108887" y1="2" y2="2.722656" />
+				<g>
+					<polygon points="10.629883,0.595215 9.395508,2.650879 11.452148,3.884277 10.055664,4.233398 8,3 9.233398,0.944336      " />
+				</g>
+			</g>
+		</g>
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="20" width="28" x="28" y="12" /><rect height="16" width="11" x="45" y="36" /><rect fill="#9E005D" height="40" width="16" x="8" y="12" /><rect fill="none" height="56" stroke="#E8ACAC" stroke-dasharray="1,2" stroke-miterlimit="10" width="36" x="4" y="4" /><g>
+			<g>
+				<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="12" x2="9.108887" y1="2" y2="2.722656" />
+				<g>
+					<polygon points="10.629883,0.595215 9.395508,2.650879 11.452148,3.884277 10.055664,4.233398 8,3 9.233398,0.944336      " />
+				</g>
+			</g>
+		</g>
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="20" width="28" x="28" y="12" /><rect height="16" width="11" x="45" y="36" /><rect height="40" width="16" x="8" y="12" /><rect fill="none" height="56" stroke="#E8ACAC" stroke-dasharray="1,2" stroke-miterlimit="10" width="36" x="4" y="4" /><g>
+			<g>
+				<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="12" x2="9.108887" y1="2" y2="2.722656" />
+				<g>
+					<polygon points="10.629883,0.595215 9.395508,2.650879 11.452148,3.884277 10.055664,4.233398 8,3 9.233398,0.944336      " />
+				</g>
+			</g>
+		</g>
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest selectionset 4,4 #9E005D" id="enclose2">
+<span class="pre-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="20" width="28" x="28" y="12" /><rect height="16" width="11" x="45" y="36" /><rect height="40" width="16" x="8" y="12" /><rect fill="none" height="56" stroke="#E8ACAC" stroke-dasharray="1,2" stroke-miterlimit="10" width="40" x="20" y="4" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="1,1" stroke-miterlimit="10" x1="4" x2="20" y1="4" y2="60" /><g>
+			<g>
+				<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="12" x2="9.108887" y1="2" y2="2.722656" />
+				<g>
+					<polygon points="10.629883,0.595215 9.395508,2.650879 11.452148,3.884277 10.055664,4.233398 8,3 9.233398,0.944336      " />
+				</g>
+			</g>
+		</g>
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect fill="#9E005D" height="20" width="28" x="28" y="12" /><rect fill="#9E005D" height="16" width="11" x="45" y="36" /><rect height="40" width="16" x="8" y="12" /><rect fill="none" height="56" stroke="#E8ACAC" stroke-dasharray="1,2" stroke-miterlimit="10" width="40" x="20" y="4" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="1,1" stroke-miterlimit="10" x1="4" x2="20" y1="4" y2="60" /><g>
+			<g>
+				<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="12" x2="9.108887" y1="2" y2="2.722656" />
+				<g>
+					<polygon points="10.629883,0.595215 9.395508,2.650879 11.452148,3.884277 10.055664,4.233398 8,3 9.233398,0.944336      " />
+				</g>
+			</g>
+		</g>
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="20" width="28" x="28" y="12" /><rect height="16" width="11" x="45" y="36" /><rect height="40" width="16" x="8" y="12" /><rect fill="none" height="56" stroke="#E8ACAC" stroke-dasharray="1,2" stroke-miterlimit="10" width="40" x="20" y="4" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="1,1" stroke-miterlimit="10" x1="4" x2="20" y1="4" y2="60" /><g>
+			<g>
+				<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="12" x2="9.108887" y1="2" y2="2.722656" />
+				<g>
+					<polygon points="10.629883,0.595215 9.395508,2.650879 11.452148,3.884277 10.055664,4.233398 8,3 9.233398,0.944336      " />
+				</g>
+			</g>
+		</g>
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest selectionset 4,4 #9E005D" id="intersect1">
+<span class="pre-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="20" width="28" x="28" y="12" /><rect height="16" width="11" x="45" y="36" /><rect height="40" width="16" x="8" y="12" /><rect fill="none" height="56" stroke="#E8ACAC" stroke-dasharray="3,1" stroke-miterlimit="10" width="36" x="4" y="4" /><g>
+			<g>
+				<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="12" x2="9.108887" y1="2" y2="2.722656" />
+				<g>
+					<polygon points="10.629883,0.595215 9.395508,2.650879 11.452148,3.884277 10.055664,4.233398 8,3 9.233398,0.944336      " />
+				</g>
+			</g>
+		</g>
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect fill="#9E005D" height="20" width="28" x="28" y="12" /><rect height="16" width="11" x="45" y="36" /><rect fill="#9E005D" height="40" width="16" x="8" y="12" /><rect fill="none" height="56" stroke="#E8ACAC" stroke-dasharray="3,1" stroke-miterlimit="10" width="36" x="4" y="4" /><g>
+			<g>
+				<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="12" x2="9.108887" y1="2" y2="2.722656" />
+				<g>
+					<polygon points="10.629883,0.595215 9.395508,2.650879 11.452148,3.884277 10.055664,4.233398 8,3 9.233398,0.944336      " />
+				</g>
+			</g>
+		</g>
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="20" width="28" x="28" y="12" /><rect height="16" width="11" x="45" y="36" /><rect height="40" width="16" x="8" y="12" /><rect fill="none" height="56" stroke="#E8ACAC" stroke-dasharray="3,1" stroke-miterlimit="10" width="36" x="4" y="4" /><g>
+			<g>
+				<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="12" x2="9.108887" y1="2" y2="2.722656" />
+				<g>
+					<polygon points="10.629883,0.595215 9.395508,2.650879 11.452148,3.884277 10.055664,4.233398 8,3 9.233398,0.944336      " />
+				</g>
+			</g>
+		</g>
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest selectionset 4,4 #9E005D" id="intersect2">
+<span class="pre-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="20" width="28" x="28" y="12" /><rect height="16" width="11" x="45" y="36" /><rect height="40" width="16" x="8" y="12" /><rect fill="none" height="56" stroke="#E8ACAC" stroke-dasharray="3,1" stroke-miterlimit="10" width="24" x="36" y="4" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="1,1" stroke-miterlimit="10" x1="4" x2="36" y1="4" y2="60" /><g>
+			<g>
+				<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="12" x2="9.108887" y1="2" y2="2.722656" />
+				<g>
+					<polygon points="10.629883,0.595215 9.395508,2.650879 11.452148,3.884277 10.055664,4.233398 8,3 9.233398,0.944336      " />
+				</g>
+			</g>
+		</g>
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect fill="#9E005D" height="20" width="28" x="28" y="12" /><rect fill="#9E005D" height="16" width="11" x="45" y="36" /><rect height="40" width="16" x="8" y="12" /><rect fill="none" height="56" stroke="#E8ACAC" stroke-dasharray="3,1" stroke-miterlimit="10" width="24" x="36" y="4" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="1,1" stroke-miterlimit="10" x1="4" x2="36" y1="4" y2="60" /><g>
+			<g>
+				<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="12" x2="9.108887" y1="2" y2="2.722656" />
+				<g>
+					<polygon points="10.629883,0.595215 9.395508,2.650879 11.452148,3.884277 10.055664,4.233398 8,3 9.233398,0.944336      " />
+				</g>
+			</g>
+		</g>
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="20" width="28" x="28" y="12" /><rect height="16" width="11" x="45" y="36" /><rect height="40" width="16" x="8" y="12" /><rect fill="none" height="56" stroke="#E8ACAC" stroke-dasharray="3,1" stroke-miterlimit="10" width="24" x="36" y="4" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="1,1" stroke-miterlimit="10" x1="4" x2="36" y1="4" y2="60" /><g>
+			<g>
+				<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="12" x2="9.108887" y1="2" y2="2.722656" />
+				<g>
+					<polygon points="10.629883,0.595215 9.395508,2.650879 11.452148,3.884277 10.055664,4.233398 8,3 9.233398,0.944336      " />
+				</g>
+			</g>
+		</g>
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest selectionset 4,4 #9E005D" id="intersect3">
+<span class="pre-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="20" width="28" x="28" y="12" /><rect height="16" width="11" x="45" y="36" /><rect height="40" width="16" x="8" y="12" /><rect fill="none" height="56" stroke="#E8ACAC" stroke-dasharray="3,1" stroke-miterlimit="10" width="24" x="36" y="4" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="0.866025,0.866025" stroke-miterlimit="10" stroke-width="0.866025" x1="36" x2="4" y1="60" y2="4" /><g>
+			<g>
+				<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="12" x2="9.108887" y1="2" y2="2.722656" />
+				<g>
+					<polygon points="10.629883,0.595215 9.395508,2.650879 11.452148,3.884277 10.055664,4.233398 8,3 9.233398,0.944336      " />
+				</g>
+			</g>
+		</g>
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect fill="#9E005D" height="20" width="28" x="28" y="12" /><rect fill="#9E005D" height="16" width="11" x="45" y="36" /><rect height="40" width="16" x="8" y="12" /><rect fill="none" height="56" stroke="#E8ACAC" stroke-dasharray="3,1" stroke-miterlimit="10" width="24" x="36" y="4" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="0.866025,0.866025" stroke-miterlimit="10" stroke-width="0.866025" x1="36" x2="4" y1="60" y2="4" /><g>
+			<g>
+				<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="12" x2="9.108887" y1="2" y2="2.722656" />
+				<g>
+					<polygon points="10.629883,0.595215 9.395508,2.650879 11.452148,3.884277 10.055664,4.233398 8,3 9.233398,0.944336      " />
+				</g>
+			</g>
+		</g>
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="20" width="28" x="28" y="12" /><rect height="16" width="11" x="45" y="36" /><rect height="40" width="16" x="8" y="12" /><rect fill="none" height="56" stroke="#E8ACAC" stroke-dasharray="3,1" stroke-miterlimit="10" width="24" x="36" y="4" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="0.866025,0.866025" stroke-miterlimit="10" stroke-width="0.866025" x1="36" x2="4" y1="60" y2="4" /><g>
+			<g>
+				<line fill="none" stroke="#000000" stroke-miterlimit="10" x1="12" x2="9.108887" y1="2" y2="2.722656" />
+				<g>
+					<polygon points="10.629883,0.595215 9.395508,2.650879 11.452148,3.884277 10.055664,4.233398 8,3 9.233398,0.944336      " />
+				</g>
+			</g>
+		</g>
+</svg>
+</span>
+</p>
+
+<h3>1.3&nbsp;&nbsp;<a href="test_combine-instructions_genfromSVG.html">Combining Instructions</a></h3>
+
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 3" id="two-moves1">
+<span class="pre-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="8" width="8" x="10" y="28" /><rect height="8" width="8" x="26" y="28" /><circle cx="36" cy="36" fill="none" r="2.5" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><line fill="none" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="36" x2="36" y1="24" y2="36" /><circle cx="20" cy="40" fill="none" r="2.5" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><line fill="none" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="20" x2="20" y1="24" y2="40" /><path d="M4,24.06c3.566,9.999,10.148-5,16-0.013" fill="none" stroke="#9ACDCD" stroke-miterlimit="10" stroke-width="0.5" /><path d="M20,24.06c3.565,9.998,10.149-4.999,16-0.013" fill="none" stroke="#9ACDCD" stroke-miterlimit="10" stroke-width="0.5" /><path d="M36,24.06c3.565,9.999,10.148-5,16-0.013" fill="none" stroke="#9ACDCD" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="52" cy="24" fill="#9ACDCD" r="1" stroke="#9ACDCD" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="52" cy="24" fill="none" r="2" stroke="#9ACDCD" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="none" height="37" stroke="#E5B7B7" stroke-dasharray="1,2" stroke-miterlimit="10" width="12" x="8" y="24" /><circle cx="4" cy="24" fill="#9ACDCD" r="1" stroke="#9ACDCD" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="none" height="37" stroke="#E5B7B7" stroke-dasharray="1,2" stroke-miterlimit="10" width="12" x="24" y="24" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="8" width="8" x="10" y="44" /><rect height="8" width="8" x="26" y="40" /><circle cx="36" cy="36" fill="none" r="2.5" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><line fill="none" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="36" x2="36" y1="24" y2="36" /><circle cx="20" cy="40" fill="none" r="2.5" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><line fill="none" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="20" x2="20" y1="24" y2="40" /><path d="M4,24.06c3.566,9.999,10.148-5,16-0.013" fill="none" stroke="#9ACDCD" stroke-miterlimit="10" stroke-width="0.5" /><path d="M20,24.06c3.565,9.998,10.149-4.999,16-0.013" fill="none" stroke="#9ACDCD" stroke-miterlimit="10" stroke-width="0.5" /><path d="M36,24.06c3.565,9.999,10.148-5,16-0.013" fill="none" stroke="#9ACDCD" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="52" cy="24" fill="#9ACDCD" r="1" stroke="#9ACDCD" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="52" cy="24" fill="none" r="2" stroke="#9ACDCD" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="none" height="37" stroke="#E5B7B7" stroke-dasharray="1,2" stroke-miterlimit="10" width="12" x="8" y="24" /><circle cx="4" cy="24" fill="#9ACDCD" r="1" stroke="#9ACDCD" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="none" height="37" stroke="#E5B7B7" stroke-dasharray="1,2" stroke-miterlimit="10" width="12" x="24" y="24" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="8" width="8" x="10" y="28" /><rect height="8" width="8" x="26" y="28" /><circle cx="36" cy="36" fill="none" r="2.5" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><line fill="none" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="36" x2="36" y1="24" y2="36" /><circle cx="20" cy="40" fill="none" r="2.5" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><line fill="none" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="20" x2="20" y1="24" y2="40" /><path d="M4,24.06c3.566,9.999,10.148-5,16-0.013" fill="none" stroke="#9ACDCD" stroke-miterlimit="10" stroke-width="0.5" /><path d="M20,24.06c3.565,9.998,10.149-4.999,16-0.013" fill="none" stroke="#9ACDCD" stroke-miterlimit="10" stroke-width="0.5" /><path d="M36,24.06c3.565,9.999,10.148-5,16-0.013" fill="none" stroke="#9ACDCD" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="52" cy="24" fill="#9ACDCD" r="1" stroke="#9ACDCD" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="52" cy="24" fill="none" r="2" stroke="#9ACDCD" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="none" height="37" stroke="#E5B7B7" stroke-dasharray="1,2" stroke-miterlimit="10" width="12" x="8" y="24" /><circle cx="4" cy="24" fill="#9ACDCD" r="1" stroke="#9ACDCD" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="none" height="37" stroke="#E5B7B7" stroke-dasharray="1,2" stroke-miterlimit="10" width="12" x="24" y="24" />
+</svg>
+</span>
+</p>
+
+<h3>2.1&nbsp;&nbsp;<a href="test_alignrel_genfromSVG.html">Align relative</a></h3>
+
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 2" id="align-rel-right">
+<span class="pre-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="16" width="8" x="12" y="12" /><rect height="8" width="12" x="24" y="44" /><rect height="12" width="12" x="40" y="28" /><rect fill="none" height="46" stroke="#E5B7B7" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="60" x2="60" y1="10" y2="39" /><polyline fill="none" points="    57,12 60,10 57,8   " stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M60,10c0,0,5.367-3.318,0-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,56,1,56,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="16" width="8" x="44" y="12" /><rect height="8" width="12" x="40" y="44" /><rect height="12" width="12" x="40" y="28" /><rect fill="none" height="46" stroke="#E5B7B7" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="60" x2="60" y1="10" y2="39" /><polyline fill="none" points="    57,12 60,10 57,8   " stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M60,10c0,0,5.367-3.318,0-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,56,1,56,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="16" width="8" x="12" y="12" /><rect height="8" width="12" x="24" y="44" /><rect height="12" width="12" x="40" y="28" /><rect fill="none" height="46" stroke="#E5B7B7" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="60" x2="60" y1="10" y2="39" /><polyline fill="none" points="    57,12 60,10 57,8   " stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M60,10c0,0,5.367-3.318,0-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,56,1,56,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 2" id="align-rel-left">
+<span class="pre-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="16" width="8" x="12" y="12" /><rect height="8" width="12" x="24" y="44" /><rect height="12" width="12" x="40" y="28" /><rect fill="none" height="46" stroke="#E5B7B7" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="8" x2="8" y1="10" y2="39" /><polyline fill="none" points="    11,12 8,10 11,8   " stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M8,10c0,0,52,0,52-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,4,0,4,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="16" width="8" x="12" y="12" /><rect height="8" width="12" x="12" y="44" /><rect height="12" width="12" x="12" y="28" /><rect fill="none" height="46" stroke="#E5B7B7" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="8" x2="8" y1="10" y2="39" /><polyline fill="none" points="    11,12 8,10 11,8   " stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M8,10c0,0,52,0,52-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,4,0,4,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="16" width="8" x="12" y="12" /><rect height="8" width="12" x="24" y="44" /><rect height="12" width="12" x="40" y="28" /><rect fill="none" height="46" stroke="#E5B7B7" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="8" x2="8" y1="10" y2="39" /><polyline fill="none" points="    11,12 8,10 11,8   " stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M8,10c0,0,52,0,52-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,4,0,4,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 2" id="align-rel-bottom">
+<span class="pre-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="16" width="8" x="12" y="12" /><rect height="8" width="12" x="24" y="44" /><rect height="12" width="12" x="40" y="28" /><rect fill="none" height="46" stroke="#E5B7B7" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><line fill="none" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="8" x2="33" y1="56" y2="56" /><polyline fill="none" points="    10,53 8,56 6,53   " stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><path d="M8,56c15-1,52-28.653,52-52" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c3,3-1,31,4,52" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="16" width="8" x="12" y="36" /><rect height="8" width="12" x="24" y="44" /><rect height="12" width="12" x="40" y="40" /><rect fill="none" height="46" stroke="#E5B7B7" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><line fill="none" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="8" x2="33" y1="56" y2="56" /><polyline fill="none" points="    10,53 8,56 6,53   " stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><path d="M8,56c15-1,52-28.653,52-52" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c3,3-1,31,4,52" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="16" width="8" x="12" y="12" /><rect height="8" width="12" x="24" y="44" /><rect height="12" width="12" x="40" y="28" /><rect fill="none" height="46" stroke="#E5B7B7" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><line fill="none" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="8" x2="33" y1="56" y2="56" /><polyline fill="none" points="    10,53 8,56 6,53   " stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><path d="M8,56c15-1,52-28.653,52-52" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c3,3-1,31,4,52" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 2" id="align-rel-top">
+<span class="pre-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="16" width="8" x="12" y="12" /><rect height="8" width="12" x="24" y="44" /><rect height="12" width="12" x="40" y="28" /><rect fill="none" height="46" stroke="#E5B7B7" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="8" x2="33" y1="10" y2="10" /><polyline fill="none" points="    10,13 8,10 6,13   " stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M6,5" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M8,10c0,0,52,0,52-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,4,0,4,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="16" width="8" x="12" y="12" /><rect height="8" width="12" x="24" y="12" /><rect height="12" width="12" x="40" y="12" /><rect fill="none" height="46" stroke="#E5B7B7" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="8" x2="33" y1="10" y2="10" /><polyline fill="none" points="    10,13 8,10 6,13   " stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M6,5" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M8,10c0,0,52,0,52-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,4,0,4,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="16" width="8" x="12" y="12" /><rect height="8" width="12" x="24" y="44" /><rect height="12" width="12" x="40" y="28" /><rect fill="none" height="46" stroke="#E5B7B7" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="8" x2="33" y1="10" y2="10" /><polyline fill="none" points="    10,13 8,10 6,13   " stroke="#E5B7B7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M6,5" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M8,10c0,0,52,0,52-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,4,0,4,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" />
+</svg>
+</span>
+</p>
+
+<h3>2.2&nbsp;&nbsp;<a href="test_alignabs_genfromSVG.html">Align absolute</a></h3>
+
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 2" id="align-abs-right">
+<span class="pre-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="16" width="8" x="12" y="12" /><rect height="8" width="12" x="24" y="44" /><rect height="12" width="12" x="40" y="28" /><rect fill="none" height="46" stroke="#FF8888" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="60" x2="60" y1="10" y2="60" /><polyline fill="none" points="    57,12 60,10 57,8   " stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M60,10c0,0,5.367-3.318,0-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,56,1,56,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="#FF8888" height="5" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" width="5" x="55" y="55" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="16" width="8" x="52" y="12" /><rect height="8" width="12" x="48" y="44" /><rect height="12" width="12" x="48" y="28" /><rect fill="none" height="46" stroke="#FF8888" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="60" x2="60" y1="10" y2="60" /><polyline fill="none" points="    57,12 60,10 57,8   " stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M60,10c0,0,5.367-3.318,0-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,56,1,56,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="#FF8888" height="5" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" width="5" x="55" y="55" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="16" width="8" x="12" y="12" /><rect height="8" width="12" x="24" y="44" /><rect height="12" width="12" x="40" y="28" /><rect fill="none" height="46" stroke="#FF8888" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="60" x2="60" y1="10" y2="60" /><polyline fill="none" points="    57,12 60,10 57,8   " stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M60,10c0,0,5.367-3.318,0-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,56,1,56,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="#FF8888" height="5" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" width="5" x="55" y="55" />
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 2" id="align-abs-left">
+<span class="pre-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="16" width="8" x="12" y="12" /><rect height="8" width="12" x="24" y="44" /><rect height="12" width="12" x="40" y="28" /><rect fill="none" height="46" stroke="#FF8888" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="8" x2="8" y1="10" y2="60" /><polyline fill="none" points="    11,12 8,10 11,8   " stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M8,10c0,0,52,0,52-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,4,0,4,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="#FF8888" height="5" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" width="5" x="8" y="55" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="16" width="8" x="8" y="12" /><rect height="8" width="12" x="8" y="44" /><rect height="12" width="12" x="8" y="28" /><rect fill="none" height="46" stroke="#FF8888" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="8" x2="8" y1="10" y2="60" /><polyline fill="none" points="    11,12 8,10 11,8   " stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M8,10c0,0,52,0,52-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,4,0,4,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="#FF8888" height="5" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" width="5" x="8" y="55" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="16" width="8" x="12" y="12" /><rect height="8" width="12" x="24" y="44" /><rect height="12" width="12" x="40" y="28" /><rect fill="none" height="46" stroke="#FF8888" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="8" x2="8" y1="10" y2="60" /><polyline fill="none" points="    11,12 8,10 11,8   " stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M8,10c0,0,52,0,52-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,4,0,4,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="#FF8888" height="5" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" width="5" x="8" y="55" />
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 2" id="align-abs-bottom">
+<span class="pre-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="16" width="8" x="12" y="12" /><rect height="8" width="12" x="24" y="44" /><rect height="12" width="12" x="40" y="28" /><rect fill="none" height="46" stroke="#FF8888" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="8" x2="62" y1="56" y2="56" /><polyline fill="none" points="    10,53 8,56 6,53   " stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><path d="M8,56c15-1,52-28.653,52-52" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c3,3-1,31,4,52" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="#FF8888" height="5" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" width="5" x="57" y="51" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="16" width="8" x="12" y="40" /><rect height="8" width="12" x="24" y="48" /><rect height="12" width="12" x="40" y="44" /><rect fill="none" height="46" stroke="#FF8888" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="8" x2="62" y1="56" y2="56" /><polyline fill="none" points="    10,53 8,56 6,53   " stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><path d="M8,56c15-1,52-28.653,52-52" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c3,3-1,31,4,52" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="#FF8888" height="5" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" width="5" x="57" y="51" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="16" width="8" x="12" y="12" /><rect height="8" width="12" x="24" y="44" /><rect height="12" width="12" x="40" y="28" /><rect fill="none" height="46" stroke="#FF8888" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="8" x2="62" y1="56" y2="56" /><polyline fill="none" points="    10,53 8,56 6,53   " stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><path d="M8,56c15-1,52-28.653,52-52" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c3,3-1,31,4,52" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="#FF8888" height="5" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" width="5" x="57" y="51" />
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 2" id="align-abs-top">
+<span class="pre-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="16" width="8" x="12" y="12" /><rect height="8" width="12" x="24" y="44" /><rect height="12" width="12" x="40" y="28" /><rect fill="none" height="46" stroke="#FF8888" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="8" x2="61" y1="10" y2="10" /><polyline fill="none" points="    10,13 8,10 6,13   " stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M6,5" fill="#990000" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M8,10c0,0,52,0,52-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,4,0,4,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="#FF8888" height="5" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" width="5" x="56" y="10" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="16" width="8" x="12" y="10" /><rect height="8" width="12" x="24" y="10" /><rect height="12" width="12" x="40" y="10" /><rect fill="none" height="46" stroke="#FF8888" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="8" x2="61" y1="10" y2="10" /><polyline fill="none" points="    10,13 8,10 6,13   " stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M6,5" fill="#990000" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M8,10c0,0,52,0,52-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,4,0,4,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="#FF8888" height="5" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" width="5" x="56" y="10" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="16" width="8" x="12" y="12" /><rect height="8" width="12" x="24" y="44" /><rect height="12" width="12" x="40" y="28" /><rect fill="none" height="46" stroke="#FF8888" stroke-dasharray="2,5" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="8" x2="61" y1="10" y2="10" /><polyline fill="none" points="    10,13 8,10 6,13   " stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M6,5" fill="#990000" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M8,10c0,0,52,0,52-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,4,0,4,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="#FF8888" height="5" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" width="5" x="56" y="10" />
+</svg>
+</span>
+</p>
+
+<h3>2.3&nbsp;&nbsp;<a href="test_moverel_genfromSVG.html">Move by vector (relative)</a></h3>
+
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 2" id="move-rel-v-down">
+<span class="pre-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="16" width="8" x="6" y="12" /><rect height="8" width="12" x="22" y="12" /><rect height="12" width="12" x="37" y="17" /><rect fill="none" height="46" stroke="#FF8888" stroke-dasharray="1,2" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="60" x2="60" y1="10" y2="43" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M60,10c0,0,5.367-3.318,0-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,56,1,56,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="43" fill="none" r="2.281" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="16" width="8" x="6" y="12" /><rect height="8" width="12" x="22" y="45" /><rect height="12" width="12" x="37" y="50" /><rect fill="none" height="46" stroke="#FF8888" stroke-dasharray="1,2" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="60" x2="60" y1="10" y2="43" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M60,10c0,0,5.367-3.318,0-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,56,1,56,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="43" fill="none" r="2.281" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="16" width="8" x="6" y="12" /><rect height="8" width="12" x="22" y="12" /><rect height="12" width="12" x="37" y="17" /><rect fill="none" height="46" stroke="#FF8888" stroke-dasharray="1,2" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="60" x2="60" y1="10" y2="43" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M60,10c0,0,5.367-3.318,0-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,56,1,56,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="43" fill="none" r="2.281" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" />
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 2" id="move-rel-dl">
+<span class="pre-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="8" width="12" x="22" y="12" /><rect height="12" width="12" x="37" y="17" /><rect fill="none" height="46" stroke="#FF8888" stroke-dasharray="1,2" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="60" x2="41" y1="10" y2="20" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M60,10c0,0,5.367-3.318,0-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,56,1,56,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="41" cy="20" fill="none" r="2.281" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="8" width="12" x="3" y="22" /><rect height="12" width="12" x="18" y="27" /><rect fill="none" height="46" stroke="#FF8888" stroke-dasharray="1,2" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="60" x2="41" y1="10" y2="20" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M60,10c0,0,5.367-3.318,0-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,56,1,56,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="41" cy="20" fill="none" r="2.281" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="8" width="12" x="22" y="12" /><rect height="12" width="12" x="37" y="17" /><rect fill="none" height="46" stroke="#FF8888" stroke-dasharray="1,2" stroke-miterlimit="10" width="52" x="8" y="10" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="60" x2="41" y1="10" y2="20" /><circle cx="4" cy="4.012" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M60,10c0,0,5.367-3.318,0-6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c0,0,56,1,56,6" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="41" cy="20" fill="none" r="2.281" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" />
+</svg>
+</span>
+</p>
+
+<h3>2.4&nbsp;&nbsp;<a href="test_moveabs_genfromSVG.html">Move to location (absolute)</a></h3>
+
+
+<h3>2.5&nbsp;&nbsp;<a href="test_create+destroy_genfromSVG.html">Create and destroy</a></h3>
+
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 2" id="clone1">
+<span class="pre-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="32" stroke="#FFFFFF" stroke-miterlimit="10" width="22" x="21" y="19" /><circle cx="4" cy="4.012207" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M36,8c1-5,14-4,24-4" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c29,0,31-2,32,4" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="36" x2="40" y1="8" y2="16" /><rect fill="none" height="1" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" width="5" x="36" y="8" /><rect fill="none" height="1" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" width="5" x="40" y="16" /><rect fill="none" height="16" stroke="#FF8888" stroke-dasharray="3,1" stroke-miterlimit="10" width="8" x="28" y="8" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="32" stroke="#FFFFFF" stroke-miterlimit="10" width="22" x="21" y="19" /><rect height="32" stroke="#FFFFFF" stroke-miterlimit="10" width="22" x="25" y="27" /><circle cx="4" cy="4.012207" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M36,8c1-5,14-4,24-4" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c29,0,31-2,32,4" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="36" x2="40" y1="8" y2="16" /><rect fill="none" height="1" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" width="5" x="36" y="8" /><rect fill="none" height="1" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" width="5" x="40" y="16" /><rect fill="none" height="16" stroke="#FF8888" stroke-dasharray="3,1" stroke-miterlimit="10" width="8" x="28" y="8" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="32" stroke="#FFFFFF" stroke-miterlimit="10" width="22" x="21" y="19" /><circle cx="4" cy="4.012207" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M36,8c1-5,14-4,24-4" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c29,0,31-2,32,4" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><line fill="none" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="36" x2="40" y1="8" y2="16" /><rect fill="none" height="1" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" width="5" x="36" y="8" /><rect fill="none" height="1" stroke="#FF8888" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" width="5" x="40" y="16" /><rect fill="none" height="16" stroke="#FF8888" stroke-dasharray="3,1" stroke-miterlimit="10" width="8" x="28" y="8" />
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 2" id="cut-horiz">
+<span class="pre-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="32" stroke="#FFFFFF" stroke-miterlimit="10" width="22" x="30" y="12" /><rect height="40" stroke="#FFFFFF" stroke-miterlimit="10" width="22" x="2" y="12" /><rect height="12" stroke="#FFFFFF" stroke-miterlimit="10" width="12" x="32" y="48" /><circle cx="4" cy="4.012207" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M56,34c2-2,9-20.625,4-30" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c53-2,54-2,52,30" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><line fill="none" stroke="#FF8888" stroke-dasharray="6,3" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="56" x2="17" y1="34" y2="34" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="22" stroke="#FFFFFF" stroke-miterlimit="10" width="22" x="30" y="12" /><rect height="10" stroke="#FFFFFF" stroke-miterlimit="10" width="22" x="30" y="34" /><rect height="40" stroke="#FFFFFF" stroke-miterlimit="10" width="22" x="2" y="12" /><rect height="12" stroke="#FFFFFF" stroke-miterlimit="10" width="12" x="32" y="48" /><circle cx="4" cy="4.012207" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M56,34c2-2,9-20.625,4-30" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c53-2,54-2,52,30" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><line fill="none" stroke="#FF8888" stroke-dasharray="6,3" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="56" x2="17" y1="34" y2="34" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="32" stroke="#FFFFFF" stroke-miterlimit="10" width="22" x="30" y="12" /><rect height="40" stroke="#FFFFFF" stroke-miterlimit="10" width="22" x="2" y="12" /><rect height="12" stroke="#FFFFFF" stroke-miterlimit="10" width="12" x="32" y="48" /><circle cx="4" cy="4.012207" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#990000" r="1" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M56,34c2-2,9-20.625,4-30" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c53-2,54-2,52,30" fill="none" stroke="#990000" stroke-miterlimit="10" stroke-width="0.5" /><line fill="none" stroke="#FF8888" stroke-dasharray="6,3" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="56" x2="17" y1="34" y2="34" />
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 2" id="delete1">
+<span class="pre-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="40" stroke="#A0A0A0" stroke-miterlimit="10" width="22" x="2" y="12" /><rect height="12" stroke="#A0A0A0" stroke-miterlimit="10" width="12" x="32" y="48" /><rect height="32" stroke="#A0A0A0" stroke-miterlimit="10" width="22" x="30" y="12" /><circle cx="4" cy="4.012207" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M27,8c0-4,25-4,33-4" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c11,0,23,0,23,4" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="6,3" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="55" x2="27" y1="52" y2="8" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="6,3" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="27" x2="55" y1="52" y2="8" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="40" stroke="#A0A0A0" stroke-miterlimit="10" width="22" x="2" y="12" /><circle cx="4" cy="4.012207" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M27,8c0-4,25-4,33-4" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c11,0,23,0,23,4" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="6,3" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="55" x2="27" y1="52" y2="8" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="6,3" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="27" x2="55" y1="52" y2="8" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="40" stroke="#A0A0A0" stroke-miterlimit="10" width="22" x="2" y="12" /><rect height="12" stroke="#A0A0A0" stroke-miterlimit="10" width="12" x="32" y="48" /><rect height="32" stroke="#A0A0A0" stroke-miterlimit="10" width="22" x="30" y="12" /><circle cx="4" cy="4.012207" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M27,8c0-4,25-4,33-4" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c11,0,23,0,23,4" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="6,3" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="55" x2="27" y1="52" y2="8" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="6,3" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="27" x2="55" y1="52" y2="8" />
+</svg>
+</span>
+</p>
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 2" id="delete2">
+<span class="pre-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="40" stroke="#A0A0A0" stroke-miterlimit="10" width="22" x="2" y="12" /><rect height="12" stroke="#A0A0A0" stroke-miterlimit="10" width="12" x="32" y="48" /><rect height="32" stroke="#A0A0A0" stroke-miterlimit="10" width="22" x="30" y="12" /><circle cx="4" cy="4.012207" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M27,8c0-4,25-4,33-4" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c11,0,23,0,23,4" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="1,5" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="55" x2="27" y1="52" y2="8" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="1,5" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="27" x2="55" y1="52" y2="8" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="40" stroke="#A0A0A0" stroke-miterlimit="10" width="22" x="2" y="12" /><rect height="12" stroke="#A0A0A0" stroke-miterlimit="10" width="12" x="32" y="48" /><circle cx="4" cy="4.012207" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M27,8c0-4,25-4,33-4" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c11,0,23,0,23,4" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="1,5" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="55" x2="27" y1="52" y2="8" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="1,5" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="27" x2="55" y1="52" y2="8" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="40" stroke="#A0A0A0" stroke-miterlimit="10" width="22" x="2" y="12" /><rect height="12" stroke="#A0A0A0" stroke-miterlimit="10" width="12" x="32" y="48" /><rect height="32" stroke="#A0A0A0" stroke-miterlimit="10" width="22" x="30" y="12" /><circle cx="4" cy="4.012207" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="60" cy="4" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M27,8c0-4,25-4,33-4" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4,4c11,0,23,0,23,4" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="1,5" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="55" x2="27" y1="52" y2="8" /><line fill="none" stroke="#E8ACAC" stroke-dasharray="1,5" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="27" x2="55" y1="52" y2="8" />
+</svg>
+</span>
+</p>
+
+<h3>3.1&nbsp;&nbsp;<a href="test_scale+resize_genfromSVG.html">Scale and resize</a></h3>
+
+<!-- NOTE: The first three items in class list define the test. Handle with care! -->
+<p class="DOMreftest normal_execution 2" id="shrink-upper">
+<span class="pre-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="7" width="4" x="14" y="30" /><rect height="3" width="10" x="23" y="31" /><rect height="10" width="6" x="38" y="26" /><rect height="7" width="1" x="49" y="37" /><circle cx="59.896" cy="7.988" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="59.896" cy="7.988" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="4" cy="8" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M12,24C26,24,38.898,8,59.896,7.988" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4.103,8.013C4,13,3,31,12,24" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="none" height="22" stroke="#E8ACAC" stroke-dasharray="2,4" stroke-miterlimit="10" width="40" x="12" y="24" /><line fill="none" stroke="#E8ACAC" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="12" x2="12" y1="19" y2="24" /><polyline fill="none" points="    10,21 12,24 14,21   " stroke="#E8ACAC" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" />
+</svg>
+</span>
+&nbsp;==&gt;&nbsp;
+<span class="post-reference">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="2" width="4" x="14" y="35" /><rect height="2" width="10" x="23" y="34" /><rect height="5" width="6" x="38" y="31" /><rect height="2" width="1" x="49" y="42" /><circle cx="59.896" cy="7.988" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="59.896" cy="7.988" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="4" cy="8" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M12,24C26,24,38.898,8,59.896,7.988" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4.103,8.013C4,13,3,31,12,24" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="none" height="22" stroke="#E8ACAC" stroke-dasharray="2,4" stroke-miterlimit="10" width="40" x="12" y="24" /><line fill="none" stroke="#E8ACAC" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="12" x2="12" y1="19" y2="24" /><polyline fill="none" points="    10,21 12,24 14,21   " stroke="#E8ACAC" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" />
+</svg>
+</span>
+&nbsp;:&nbsp;&nbsp;&nbsp;
+<span class="testDOM">
+<svg viewbox="-60 0 104 164" width="64" height="64">
+<rect height="7" width="4" x="14" y="30" /><rect height="3" width="10" x="23" y="31" /><rect height="10" width="6" x="38" y="26" /><rect height="7" width="1" x="49" y="37" /><circle cx="59.896" cy="7.988" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="59.896" cy="7.988" fill="none" r="2.25" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><circle cx="4" cy="8" fill="#9BC9C7" r="1" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M12,24C26,24,38.898,8,59.896,7.988" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><path d="M4.103,8.013C4,13,3,31,12,24" fill="none" stroke="#9BC9C7" stroke-miterlimit="10" stroke-width="0.5" /><rect fill="none" height="22" stroke="#E8ACAC" stroke-dasharray="2,4" stroke-miterlimit="10" width="40" x="12" y="24" /><line fill="none" stroke="#E8ACAC" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" x1="12" x2="12" y1="19" y2="24" /><polyline fill="none" points="    10,21 12,24 14,21   " stroke="#E8ACAC" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" />
+</svg>
+</span>
+</p>
+
+
+<footer>
+<p><b>Version 0.0.12</b></p>
+<p>
+Copyright 2017 Martin Brösamle.<br>
+All rights reserved.<br>
+</p>
+</footer>
+
+<script src="../spec/spec_DOMrefsheet.js"></script>
+</body>
+
+</html>


### PR DESCRIPTION
Fixes #7 

`Svgretrieve` now fully wraps `getIntersectionList`, `getEnclosureList`, `checkIntersection`, and `checkEnclosure`: Positions are always given in SVG coordinates no matter how the viewBox, width, height etc require the SVG coords to be transformed so as to hit the correct element.

The new methods `getIntersectedElements`, `getEnclosedElements`, `checkIntersected`, `checkEnclosed` internally use `svgroot.getCTM()` to translate SVG coords into viewport coordinates. 

A new testsheet `test-manual_viewbox-and-scale_passing-distorted.html` was generated manually by (temporarily) changing the viewBox attribute in the template.