### PR TITLE
Avoid passing svgroot element as a function parameter.

### DIFF
--- a/bin/DemoTemplates.py
+++ b/bin/DemoTemplates.py
@@ -79,6 +79,14 @@ Powered by SVG, JS, and the DOM.
 </footer>
 """
 
+Demo_ScriptInBody_str = """
+<script>
+window.onload = function () {
+    Clip8controler.init(document.getElementById("clip8svgroot"));
+}
+</script>"""
+
+
 
 Body = Template("""
 <body>
@@ -90,6 +98,7 @@ $link2
 <h1><span class="sndtitle">$pagetitle&nbsp;|</span>&nbsp;$chapter</h1>
 $DEMOS
 $FOOTER
+$SCRIPT
 </body>
 """)
 

--- a/bin/svg2demo.py
+++ b/bin/svg2demo.py
@@ -92,7 +92,8 @@ while len(SCT.demos) > 0:
                                         chapter=chapter, chaptercnt="Demos",
                                         DEMOS=demopageHTML,
                                         link1=backlinkHTML, link2=nextlinkHTML,
-                                        FOOTER=footerHTML)
+                                        FOOTER=footerHTML,
+                                        SCRIPT=TEM.Demo_ScriptInBody_str)
         headerHTML = TEM.Header.substitute(dependencies=TEM.DependClip8_str, chapter=chapter)
         documentHTML = TEM.Document.substitute(HEADER=headerHTML, BODY=bodyHTML)
         output_file = codecs.open(outFN, "w", encoding="utf-8", errors="xmlcharrefreplace")
@@ -133,7 +134,8 @@ bodyHTML = TEM.Body.substitute(pagetitle='clip_8',
                                chapter="Demos", chaptercnt="Demos",
                                DEMOS=tocsectionsHTML,
                                link1=backlinkHTML, link2=nextlinkHTML,
-                               FOOTER=footerHTML)
+                               FOOTER=footerHTML,
+                               SCRIPT="")
 headerHTML = TEM.Header.substitute(dependencies=TEM.DependClip8_str, chapter="Demos")
 documentHTML = TEM.Document.substitute(HEADER=headerHTML, BODY=bodyHTML)
 

--- a/demos/ADConverter.html
+++ b/demos/ADConverter.html
@@ -187,6 +187,12 @@ Powered by SVG, JS, and the DOM.
 </p>
 </footer>
 
+
+<script>
+window.onload = function () {
+    Clip8controler.init(document.getElementById("clip8svgroot"));
+}
+</script>
 </body>
 
 </html>

--- a/demos/christmas1.html
+++ b/demos/christmas1.html
@@ -240,6 +240,12 @@ Powered by SVG, JS, and the DOM.
 </p>
 </footer>
 
+
+<script>
+window.onload = function () {
+    Clip8controler.init(document.getElementById("clip8svgroot"));
+}
+</script>
 </body>
 
 </html>

--- a/demos/counter3.html
+++ b/demos/counter3.html
@@ -1056,6 +1056,12 @@ Powered by SVG, JS, and the DOM.
 </p>
 </footer>
 
+
+<script>
+window.onload = function () {
+    Clip8controler.init(document.getElementById("clip8svgroot"));
+}
+</script>
 </body>
 
 </html>

--- a/demos/index.html
+++ b/demos/index.html
@@ -94,6 +94,7 @@ Powered by SVG, JS, and the DOM.
 </p>
 </footer>
 
+
 </body>
 
 </html>

--- a/demos/loom1.html
+++ b/demos/loom1.html
@@ -171,6 +171,12 @@ Powered by SVG, JS, and the DOM.
 </p>
 </footer>
 
+
+<script>
+window.onload = function () {
+    Clip8controler.init(document.getElementById("clip8svgroot"));
+}
+</script>
 </body>
 
 </html>

--- a/demos/loom2.html
+++ b/demos/loom2.html
@@ -157,6 +157,12 @@ Powered by SVG, JS, and the DOM.
 </p>
 </footer>
 
+
+<script>
+window.onload = function () {
+    Clip8controler.init(document.getElementById("clip8svgroot"));
+}
+</script>
 </body>
 
 </html>

--- a/demos/loom3.html
+++ b/demos/loom3.html
@@ -283,6 +283,12 @@ Powered by SVG, JS, and the DOM.
 </p>
 </footer>
 
+
+<script>
+window.onload = function () {
+    Clip8controler.init(document.getElementById("clip8svgroot"));
+}
+</script>
 </body>
 
 </html>

--- a/demos/loom4.html
+++ b/demos/loom4.html
@@ -291,6 +291,12 @@ Powered by SVG, JS, and the DOM.
 </p>
 </footer>
 
+
+<script>
+window.onload = function () {
+    Clip8controler.init(document.getElementById("clip8svgroot"));
+}
+</script>
 </body>
 
 </html>

--- a/js/clip8.js
+++ b/js/clip8.js
@@ -101,9 +101,9 @@ var Clip8 = {
         return result;
     },
 
-    retrieveISCElements: function (arearect, svgroot, tagsI, tagsS, tagsC) {
+    retrieveISCElements: function (arearect, tagsI, tagsS, tagsC) {
         var debug = false;
-        if (debug) console.log("[RETRIEVEISCELEMENTS] arearect, svgroot:", arearect, svgroot);
+        if (debug) console.log("[RETRIEVEISCELEMENTS] arearect:", arearect);
         var hitlist = Svgretrieve.getIntersectedElements(arearect);
         if (debug)  console.log("[retrieveISCElements] hitlist:", hitlist);
         hitlist = Clip8.removeFalsePositives(arearect, hitlist);
@@ -145,16 +145,16 @@ var Clip8 = {
         return [I, S, C];
     },
 
-    retrieveCoreSelector: function (S, originarea, svgroot) {
+    retrieveCoreSelector: function (S, originarea) {
         var debug = false;
-        if (debug) console.log("[RETRIEVECORESELECTOR] S, svgroot:", S, svgroot);
+        if (debug) console.log("[RETRIEVECORESELECTOR] S:", S);
         var coreS;
         if (S[Clip8.LINETAG].length == 1) {
             // there is a selector
             var epsilon = 0.01;
             var lineend = Svgdom.getBothEndsOfLine_arranged(originarea, S[Clip8.LINETAG][0])[1];
             var arearect = Svgdom.epsilonRectAt(lineend, epsilon);
-            var isc = Clip8.retrieveISCElements(arearect, svgroot, Clip8.TAGS, Clip8.TAGS, Clip8.TAGS);
+            var isc = Clip8.retrieveISCElements(arearect, Clip8.TAGS, Clip8.TAGS, Clip8.TAGS);
             if (debug) console.log("[retrieveCoreSelector] local isc [0, 1, 2]:", isc[0], isc[1], isc[2]);
             coreS = isc[1];
         }
@@ -182,7 +182,7 @@ var Clip8 = {
         return selection;
     },
 
-    selectedElementSet: function (selectorcore, svgroot) {
+    selectedElementSet: function (selectorcore) {
         /** Determine the set of selected elements based on given selector core.
          *  `selectorcore` is the list of SVG DOM elments being the core selector
          *  (excluding connectors). Typically these elements graphically depict an area.
@@ -190,14 +190,14 @@ var Clip8 = {
          */
 
         var debug = true;
-        if (debug) console.log("[SELECTEDELEMENTSET] selectorcore, svgroot:", selectorcore, svgroot);
+        if (debug) console.log("[SELECTEDELEMENTSET] selectorcore:", selectorcore);
         // List of selected Elements based on primary selector
         var hitlist;
         var s; // The rectangle to be used as area of selection
         if (selectorcore[0] instanceof SVGRectElement) {
             // rectangle
             var dashes = selectorcore[0].getAttribute("stroke-dasharray").split(",").map(parseFloat);
-            s = svgroot.createSVGRect();
+            s = Clip8.svgroot.createSVGRect();
             s.x = selectorcore[0].x.baseVal.value;
             s.y = selectorcore[0].y.baseVal.value;
             s.width = selectorcore[0].width.baseVal.value;
@@ -206,7 +206,7 @@ var Clip8 = {
         else if (selectorcore[0] instanceof SVGLineElement && selectorcore[1] instanceof SVGLineElement) {
             // DELETE: X icon defines the selection area
             var dashes = selectorcore[0].getAttribute("stroke-dasharray").split(",").map(parseFloat);
-            s = svgroot.createSVGRect();
+            s = Clip8.svgroot.createSVGRect();
             var x1, y1, x2, y2;
             x1 = parseFloat(selectorcore[0].getAttribute("x1"));
             y1 = parseFloat(selectorcore[0].getAttribute("y1"));
@@ -236,7 +236,7 @@ var Clip8 = {
     TERMINATE: 0,
     CONTINUE: 1,
     EXECUTE: 2,
-    moveIP: function (C, arearect, svgroot) {
+    moveIP: function (C, arearect) {
         var debug = false;
         var epsilon = 0.01;
         if ( C[Clip8.CIRCLETAG].length == 2 )
@@ -256,11 +256,11 @@ var Clip8 = {
                 var arearectA = Svgdom.epsilonRectAt(endpoints[0], epsilon);
                 var localISCa = Clip8.retrieveISCElements(
                                     arearectA,
-                                    svgroot, Clip8.TAGS, Clip8.TAGS, Clip8.TAGS);
+                                    Clip8.TAGS, Clip8.TAGS, Clip8.TAGS);
                 var arearectB = Svgdom.epsilonRectAt(endpoints[1], epsilon);
                 var localISCb = Clip8.retrieveISCElements(
                                     arearectB,
-                                    svgroot, Clip8.TAGS, Clip8.TAGS, Clip8.TAGS);
+                                    Clip8.TAGS, Clip8.TAGS, Clip8.TAGS);
                 var condISC;            // the ISC where the condition is attached
                 var oppositeISC;        // the ISC opposite to where the condition is attached
                 var condarearect;       // the arearect where the condition is attached
@@ -287,10 +287,10 @@ var Clip8 = {
                     oppositeISC = localISCb;
                     oppositearearect = arearectB;
                 }
-                var retrselector = Clip8.retrieveCoreSelector(condISC[1], condarearect, svgroot);
+                var retrselector = Clip8.retrieveCoreSelector(condISC[1], condarearect);
                 var selectortype = retrselector[0];
                 var coreselector = retrselector[1];
-                var condselected = Clip8.selectedElementSet(coreselector, svgroot);
+                var condselected = Clip8.selectedElementSet(coreselector);
                 if (condselected.length > 0)
                     if (condISC[2][Clip8.PATHTAG].length == 1) {
                         Clip8.ip = condISC[2][Clip8.PATHTAG][0];   // move instruction pointer to cond side
@@ -312,7 +312,7 @@ var Clip8 = {
                 var mergearea = Svgdom.epsilonRectAt(points[1], epsilon)
                 var localISC = Clip8.retrieveISCElements(
                                     mergearea,
-                                    svgroot, Clip8.TAGS, Clip8.TAGS, Clip8.TAGS);
+                                    Clip8.TAGS, Clip8.TAGS, Clip8.TAGS);
                 if (localISC[2][Clip8.PATHTAG].length == 1) {
                     Clip8.ip = localISC[2][Clip8.PATHTAG][0];   // move instruction pointer
                     Clip8.pminus1_area = mergearea;             // indicate old instruction pointer area
@@ -401,7 +401,7 @@ var Clip8 = {
         var p0area = Svgdom.epsilonRectAt(p0, epsilon);
         // reset the blocklist and fetch a new instruction
         Clip8.blocklist = [Clip8.ip];
-        var ISC0 = Clip8.retrieveISCElements(p0area, Clip8.svgroot, Clip8.TAGS, Clip8.TAGS, Clip8.TAGS);
+        var ISC0 = Clip8.retrieveISCElements(p0area, Clip8.TAGS, Clip8.TAGS, Clip8.TAGS);
         var I0 = ISC0[0];
         var S0 = ISC0[1];
         var C0 = ISC0[2];
@@ -459,7 +459,7 @@ var Clip8 = {
                 var angledir = Clip8decode.directionOfPolyAngle(thepoly, epsilon, minlen);
                 if (debug) console.log("[executeOneOperation] angle direction:", angledir);
                 var arearect = Svgdom.epsilonRectAt(bothends[1], epsilon);
-                var ISC1 = Clip8.retrieveISCElements(arearect, Clip8.svgroot, Clip8.TAGS, Clip8.TAGS, Clip8.TAGS);
+                var ISC1 = Clip8.retrieveISCElements(arearect, Clip8.TAGS, Clip8.TAGS, Clip8.TAGS);
                 var I1 = ISC1[0];
                 var S1 = ISC1[1];
                 if (debug) console.log("[executeOneOperation] I1:", I1.reduce(function(a,b) {return a.concat(b)}));

--- a/js/clip8.js
+++ b/js/clip8.js
@@ -374,9 +374,9 @@ var Clip8 = {
         throw "Failed to idendify point of entry."
     },
 
-    executeOneOperation: function(svgroot) {
+    executeOneOperation: function() {
         var debug = true;
-        if (debug) console.log("[EXECUTEONEOPERATION] Clip8.ip, svgroot:", Clip8.ip, svgroot);
+        if (debug) console.log("[EXECUTEONEOPERATION] Clip8.ip, svgroot:", Clip8.ip, Clip8.svgroot);
         Clip8.cyclescounter++;
         if (Clip8.maxcycles > 0 && Clip8.cyclescounter >= Clip8.maxcycles) {
             Clip8.clearExecTimer();
@@ -397,10 +397,10 @@ var Clip8 = {
                 p0 = p0candidates[1];
         else
             p0 = p0candidates[0];
-        var p0area = Svgdom.epsilonRectAt(p0, epsilon, svgroot);
+        var p0area = Svgdom.epsilonRectAt(p0, epsilon, Clip8.svgroot);
         // reset the blocklist and fetch a new instruction
         Clip8.blocklist = [Clip8.ip];
-        var ISC0 = Clip8.retrieveISCElements(p0area, svgroot, Clip8.TAGS, Clip8.TAGS, Clip8.TAGS);
+        var ISC0 = Clip8.retrieveISCElements(p0area, Clip8.svgroot, Clip8.TAGS, Clip8.TAGS, Clip8.TAGS);
         var I0 = ISC0[0];
         var S0 = ISC0[1];
         var C0 = ISC0[2];
@@ -422,7 +422,7 @@ var Clip8 = {
                     Clip8._highlightElement(C0[i][j]);
             }
         }
-        var execstatus = Clip8.moveIP(C0, p0area, svgroot);
+        var execstatus = Clip8.moveIP(C0, p0area, Clip8.svgroot);
         switch (execstatus) {
             case Clip8.EXECUTE:
                 break;      // redundant but more readable.
@@ -432,11 +432,11 @@ var Clip8 = {
                 Clip8.clearExecTimer();
                 return;     // stop execution
         }
-        var retrselector = Clip8.retrieveCoreSelector(S0, p0area, svgroot)
+        var retrselector = Clip8.retrieveCoreSelector(S0, p0area, Clip8.svgroot)
         var selectortype = retrselector[0];
         var coreselector = retrselector[1];
         if      (selectortype == Clip8.RECTSELECTOR)
-            var selectedelements1 = Clip8.selectedElementSet(coreselector, svgroot);
+            var selectedelements1 = Clip8.selectedElementSet(coreselector, Clip8.svgroot);
         else if (selectortype == Clip8.UNKNOWNSELECTOR)
             {}
         else
@@ -457,8 +457,8 @@ var Clip8 = {
                 var thepoly = I0[Clip8.POLYLINETAG][0];
                 var angledir = Clip8decode.directionOfPolyAngle(thepoly, epsilon, minlen);
                 if (debug) console.log("[executeOneOperation] angle direction:", angledir);
-                var arearect = Svgdom.epsilonRectAt(bothends[1], epsilon, svgroot);
-                var ISC1 = Clip8.retrieveISCElements(arearect, svgroot, Clip8.TAGS, Clip8.TAGS, Clip8.TAGS);
+                var arearect = Svgdom.epsilonRectAt(bothends[1], epsilon, Clip8.svgroot);
+                var ISC1 = Clip8.retrieveISCElements(arearect, Clip8.svgroot, Clip8.TAGS, Clip8.TAGS, Clip8.TAGS);
                 var I1 = ISC1[0];
                 var S1 = ISC1[1];
                 if (debug) console.log("[executeOneOperation] I1:", I1.reduce(function(a,b) {return a.concat(b)}));
@@ -500,17 +500,18 @@ var Clip8 = {
                         case 'LEFT':
                         case 'RIGHT':
                             // CUT
-                            var stripeNaboveNbelow = Svgretrieve.enclosingFullHeightStripe(theline, svgroot);
+                            var stripeNaboveNbelow = Svgretrieve.enclosingFullHeightStripe(theline, Clip8.svgroot);
                             var stripe = stripeNaboveNbelow[0];
                             var above = stripeNaboveNbelow[1];
                             var below = stripeNaboveNbelow[2];
 
                             if (debug) console.log("[executeOneOperation] stripe, above, below:", stripe, above, below);
-                            var hitlist = Svgretrieve.getEnclosedElements(stripe, svgroot);
+                            var hitlist = Svgretrieve.getEnclosedElements(stripe, Clip8.svgroot);
                             if (debug) console.log("[executeOneOperation] hitlist:", hitlist);
                             var selectedelements1 = []
                             for (var i = 0; i < hitlist.length; i++)
-                                if ( Svgretrieve.checkIntersected(hitlist[i], above, svgroot) && Svgretrieve.checkIntersected(hitlist[i], below, svgroot) )
+                                if ( Svgretrieve.checkIntersected(hitlist[i], above, Clip8.svgroot) &&
+                                     Svgretrieve.checkIntersected(hitlist[i], below, Clip8.svgroot) )
                                     selectedelements1.push(hitlist[i]);
 
                             selectedelements1 = Clip8.reduceSelectionHitlist(selectedelements1);
@@ -522,18 +523,18 @@ var Clip8 = {
                         case 'DO-RE':
                         case 'DO-LE':
                             // DEL
-                            var p3 = svgroot.createSVGPoint();
-                            var p4 = svgroot.createSVGPoint();
+                            var p3 = Clip8.svgroot.createSVGPoint();
+                            var p4 = Clip8.svgroot.createSVGPoint();
                             p3.x = theline.getAttribute("x1");
                             p3.y = theline.getAttribute("y2");
                             p4.x = theline.getAttribute("x2");
                             p4.y = theline.getAttribute("y1");
-                            var opposite_diagonals = Svgretrieve.getLinesFromTo(p3, p4, epsilon, svgroot);
+                            var opposite_diagonals = Svgretrieve.getLinesFromTo(p3, p4, epsilon, Clip8.svgroot);
                             if (debug) console.log("[executeOneOperation] opposite_diagonals:", opposite_diagonals);
-                            opposite_diagonals = Clip8.removeFalsePositives(Svgdom.epsilonRectAt(p3, epsilon, svgroot), opposite_diagonals);
+                            opposite_diagonals = Clip8.removeFalsePositives(Svgdom.epsilonRectAt(p3, epsilon, Clip8.svgroot), opposite_diagonals);
                             if (debug) console.log("[executeOneOperation] opposite_diagonals (red):", opposite_diagonals);
                             if (opposite_diagonals.length != 1) throw "[executeOneOperation / del] ambiguous diagonals.";
-                            var selectedelements1 = Clip8.selectedElementSet([theline, opposite_diagonals[0]], svgroot);
+                            var selectedelements1 = Clip8.selectedElementSet([theline, opposite_diagonals[0]], Clip8.svgroot);
                             for (var i = 0; i < selectedelements1.length; i++)
                                 selectedelements1[i].parentElement.removeChild(selectedelements1[i]);
                             break;
@@ -546,7 +547,7 @@ var Clip8 = {
                         bothends[1],
                         theline.getAttribute("stroke-width"),       // use as minimum radius
                         theline.getAttribute("stroke-width") * 4,   // use as minimum radius
-                        svgroot);
+                        Clip8.svgroot);
                     if (debug) console.log("[executeOneOperation/move-rel] circles:", circles);
                     var deltaX, deltaY;
                     deltaX = bothends[1].x-bothends[0].x;
@@ -567,20 +568,20 @@ var Clip8 = {
             throw "Could not decode instruction X";
     },
 
-    init: function () {
-        var svgroot = document.getElementById("clip8svgroot");
+    init: function (svgroot) {
+        console.log("[clip8.init]", svgroot);
         if (!(svgroot instanceof SVGElement)) { throw "[clip8] no SVG root."; }
         // crucial init operations
         Svgdom.setSVGNS(svgroot.namespaceURI);
         Clip8.cyclescounter = 0
+        Clip8.svgroot = svgroot;
         Clip8.ip = Clip8.initControlFlow(svgroot);     // instruction pointer: the active control flow path
         return svgroot;
     },
 
     envokeOperation: function () {
-        var svgroot = Clip8.init();
-        console.log("[CLIP8ENVOKEOPERATION] svgroot:", svgroot);
-        Clip8.exectimer = setInterval( function() { Clip8.executeOneOperation(svgroot) }, 50 );
+        console.log("[CLIP8ENVOKEOPERATION] svgroot:", Clip8.svgroot);
+        Clip8.exectimer = setInterval( function() { Clip8.executeOneOperation() }, 50 );
     },
 
     clearExecTimer: function () {
@@ -590,7 +591,13 @@ var Clip8 = {
 
 var Clip8controler = {
     svgroot: null,
-    initialised: false,
+
+    init: function (svgroot) {
+        console.log("INIT", svgroot);
+        Clip8.visualise = true;
+        Clip8controler.svgroot;
+        Clip8.init(svgroot);
+    },
 
     playAction: function () {
         console.log("PLAY clip_8");
@@ -606,13 +613,7 @@ var Clip8controler = {
 
     stepAction: function () {
         console.log("STEP clip_8");
-        if (! Clip8controler.initialised) {
-            Clip8.visualise = true;
-            Clip8controler.svgroot = Clip8.init();
-            Clip8controler.initialised = true;
-        }
-        else
-            Clip8.executeOneOperation(Clip8controler.svgroot);
+        Clip8.executeOneOperation(Clip8controler.svgroot);
     },
 
     stopAction: function () {

--- a/js/clip8.js
+++ b/js/clip8.js
@@ -331,10 +331,10 @@ var Clip8 = {
         return Clip8.EXECUTE;
     },
 
-    initControlFlow: function (svgroot) {
+    initControlFlow: function () {
         var debug = true;
         var debugcolour = false;
-        var circles = svgroot.getElementsByTagName("circle");
+        var circles = Clip8.svgroot.getElementsByTagName("circle");
         var centres_offilled = [];  // Centres of filled circles (candidates).
         var centrareas = [];        // Epsilon rectangles arount each circle centre.
         var initialflow = null;
@@ -377,7 +377,7 @@ var Clip8 = {
 
     executeOneOperation: function() {
         var debug = true;
-        if (debug) console.log("[EXECUTEONEOPERATION] Clip8.ip, svgroot:", Clip8.ip, Clip8.svgroot);
+        if (debug) console.log("[EXECUTEONEOPERATION] Clip8.ip, svgroot:", Clip8.ip);
         Clip8.cyclescounter++;
         if (Clip8.maxcycles > 0 && Clip8.cyclescounter >= Clip8.maxcycles) {
             Clip8.clearExecTimer();
@@ -423,7 +423,7 @@ var Clip8 = {
                     Clip8._highlightElement(C0[i][j]);
             }
         }
-        var execstatus = Clip8.moveIP(C0, p0area, Clip8.svgroot);
+        var execstatus = Clip8.moveIP(C0, p0area);
         switch (execstatus) {
             case Clip8.EXECUTE:
                 break;      // redundant but more readable.
@@ -433,11 +433,11 @@ var Clip8 = {
                 Clip8.clearExecTimer();
                 return;     // stop execution
         }
-        var retrselector = Clip8.retrieveCoreSelector(S0, p0area, Clip8.svgroot)
+        var retrselector = Clip8.retrieveCoreSelector(S0, p0area)
         var selectortype = retrselector[0];
         var coreselector = retrselector[1];
         if      (selectortype == Clip8.RECTSELECTOR)
-            var selectedelements1 = Clip8.selectedElementSet(coreselector, Clip8.svgroot);
+            var selectedelements1 = Clip8.selectedElementSet(coreselector);
         else if (selectortype == Clip8.UNKNOWNSELECTOR)
             {}
         else
@@ -535,7 +535,7 @@ var Clip8 = {
                             opposite_diagonals = Clip8.removeFalsePositives(Svgdom.epsilonRectAt(p3, epsilon), opposite_diagonals);
                             if (debug) console.log("[executeOneOperation] opposite_diagonals (red):", opposite_diagonals);
                             if (opposite_diagonals.length != 1) throw "[executeOneOperation / del] ambiguous diagonals.";
-                            var selectedelements1 = Clip8.selectedElementSet([theline, opposite_diagonals[0]], Clip8.svgroot);
+                            var selectedelements1 = Clip8.selectedElementSet([theline, opposite_diagonals[0]]);
                             for (var i = 0; i < selectedelements1.length; i++)
                                 selectedelements1[i].parentElement.removeChild(selectedelements1[i]);
                             break;
@@ -576,7 +576,7 @@ var Clip8 = {
         Svgretrieve.init(svgroot);
         Clip8.cyclescounter = 0
         Clip8.svgroot = svgroot;
-        Clip8.ip = Clip8.initControlFlow(svgroot);     // instruction pointer: the active control flow path
+        Clip8.ip = Clip8.initControlFlow();     // instruction pointer: the active control flow path
         return svgroot;
     },
 

--- a/js/clip8.js
+++ b/js/clip8.js
@@ -152,7 +152,7 @@ var Clip8 = {
             // there is a selector
             var epsilon = 0.01;
             var lineend = Svgdom.getBothEndsOfLine_arranged(originarea, S[Clip8.LINETAG][0])[1];
-            var arearect = Svgdom.epsilonRectAt(lineend, epsilon, svgroot);
+            var arearect = Svgdom.epsilonRectAt(lineend, epsilon);
             var isc = Clip8.retrieveISCElements(arearect, svgroot, Clip8.TAGS, Clip8.TAGS, Clip8.TAGS);
             if (debug) console.log("[retrieveCoreSelector] local isc [0, 1, 2]:", isc[0], isc[1], isc[2]);
             coreS = isc[1];
@@ -252,11 +252,11 @@ var Clip8 = {
                 console.log("ALTERNATIVE");
                 var endpoints = [points[0], points[2]];
                 if (debug) console.log("[moveIP] endpoints:", endpoints);
-                var arearectA = Svgdom.epsilonRectAt(endpoints[0], epsilon, svgroot);
+                var arearectA = Svgdom.epsilonRectAt(endpoints[0], epsilon);
                 var localISCa = Clip8.retrieveISCElements(
                                     arearectA,
                                     svgroot, Clip8.TAGS, Clip8.TAGS, Clip8.TAGS);
-                var arearectB = Svgdom.epsilonRectAt(endpoints[1], epsilon, svgroot);
+                var arearectB = Svgdom.epsilonRectAt(endpoints[1], epsilon);
                 var localISCb = Clip8.retrieveISCElements(
                                     arearectB,
                                     svgroot, Clip8.TAGS, Clip8.TAGS, Clip8.TAGS);
@@ -308,7 +308,7 @@ var Clip8 = {
             else {
                 // Merge
                 console.log("MERGE");
-                var mergearea = Svgdom.epsilonRectAt(points[1], epsilon, svgroot)
+                var mergearea = Svgdom.epsilonRectAt(points[1], epsilon)
                 var localISC = Clip8.retrieveISCElements(
                                     mergearea,
                                     svgroot, Clip8.TAGS, Clip8.TAGS, Clip8.TAGS);
@@ -341,7 +341,7 @@ var Clip8 = {
         for (var i = 0, c; i < circles.length; i++) {
             if (debugcolour) circles[i].setAttribute("stroke", "#95C9EF");
             c = Svgdom.getCentrePoint(circles[i]);
-            centrareas.push ( Svgdom.epsilonRectAt(c, epsilon, svgroot) );
+            centrareas.push ( Svgdom.epsilonRectAt(c, epsilon) );
             if (circles[i].getAttribute("fill", "none") != "none") {
                 if (debugcolour) circles[i].setAttribute("fill", "#3EA3ED");
                 centres_offilled.push(c);
@@ -358,7 +358,7 @@ var Clip8 = {
             if (hitcount == 1) {
                 // found circle not surrounded by any other (= an area being the centre of one circle).
                 var hit = centres_offilled[i];
-                var hitarea = Svgdom.epsilonRectAt(hit, epsilon, svgroot);
+                var hitarea = Svgdom.epsilonRectAt(hit, epsilon);
                 var hitlist = Svgretrieve.getIntersectedElements(hitarea, svgroot);
                 if (debug) console.log("[initControlFlow] , hit, hitarea, hitlist:", hit, hitarea, hitlist);
                 for ( var k = 0; k < hitlist.length; k++ ) {
@@ -397,7 +397,7 @@ var Clip8 = {
                 p0 = p0candidates[1];
         else
             p0 = p0candidates[0];
-        var p0area = Svgdom.epsilonRectAt(p0, epsilon, Clip8.svgroot);
+        var p0area = Svgdom.epsilonRectAt(p0, epsilon);
         // reset the blocklist and fetch a new instruction
         Clip8.blocklist = [Clip8.ip];
         var ISC0 = Clip8.retrieveISCElements(p0area, Clip8.svgroot, Clip8.TAGS, Clip8.TAGS, Clip8.TAGS);
@@ -457,7 +457,7 @@ var Clip8 = {
                 var thepoly = I0[Clip8.POLYLINETAG][0];
                 var angledir = Clip8decode.directionOfPolyAngle(thepoly, epsilon, minlen);
                 if (debug) console.log("[executeOneOperation] angle direction:", angledir);
-                var arearect = Svgdom.epsilonRectAt(bothends[1], epsilon, Clip8.svgroot);
+                var arearect = Svgdom.epsilonRectAt(bothends[1], epsilon);
                 var ISC1 = Clip8.retrieveISCElements(arearect, Clip8.svgroot, Clip8.TAGS, Clip8.TAGS, Clip8.TAGS);
                 var I1 = ISC1[0];
                 var S1 = ISC1[1];
@@ -531,7 +531,7 @@ var Clip8 = {
                             p4.y = theline.getAttribute("y1");
                             var opposite_diagonals = Svgretrieve.getLinesFromTo(p3, p4, epsilon, Clip8.svgroot);
                             if (debug) console.log("[executeOneOperation] opposite_diagonals:", opposite_diagonals);
-                            opposite_diagonals = Clip8.removeFalsePositives(Svgdom.epsilonRectAt(p3, epsilon, Clip8.svgroot), opposite_diagonals);
+                            opposite_diagonals = Clip8.removeFalsePositives(Svgdom.epsilonRectAt(p3, epsilon), opposite_diagonals);
                             if (debug) console.log("[executeOneOperation] opposite_diagonals (red):", opposite_diagonals);
                             if (opposite_diagonals.length != 1) throw "[executeOneOperation / del] ambiguous diagonals.";
                             var selectedelements1 = Clip8.selectedElementSet([theline, opposite_diagonals[0]], Clip8.svgroot);
@@ -572,7 +572,7 @@ var Clip8 = {
         console.log("[clip8.init]", svgroot);
         if (!(svgroot instanceof SVGElement)) { throw "[clip8] no SVG root."; }
         // crucial init operations
-        Svgdom.setSVGNS(svgroot.namespaceURI);
+        Svgdom.init(svgroot);
         Clip8.cyclescounter = 0
         Clip8.svgroot = svgroot;
         Clip8.ip = Clip8.initControlFlow(svgroot);     // instruction pointer: the active control flow path

--- a/js/clip8.js
+++ b/js/clip8.js
@@ -592,11 +592,18 @@ var Clip8 = {
 var Clip8controler = {
     svgroot: null,
 
-    init: function (svgroot) {
+    init: function (svgroot, visualise) {
         console.log("INIT", svgroot);
-        Clip8.visualise = true;
+        Clip8.visualise = visualise;
         Clip8controler.svgroot;
         Clip8.init(svgroot);
+    },
+
+    testRun: function (maxcycles) {
+        console.log("TEST-RUN: maxcycles:", maxcycles);
+        Clip8.visualise = false;
+        Clip8.maxcycles = maxcycles;
+        Clip8.envokeOperation();
     },
 
     playAction: function () {

--- a/js/svgdom.js
+++ b/js/svgdom.js
@@ -20,10 +20,12 @@
 "use strict";
 
 var Svgdom = {
+    svgroot: undefined,
     SVGNS: undefined,
 
-    setSVGNS: function (namespace) {
-        Svgdom.SVGNS = namespace;
+    init: function (svgroot) {
+        Svgdom.svgroot = svgroot;
+        Svgdom.SVGNS = svgroot.namespaceURI;
     },
 
     addGroup: function (parentel) {
@@ -32,10 +34,10 @@ var Svgdom = {
         return g;
     },
 
-    newSVGRect: function (x, y, width, height, svgroot) {
+    newSVGRect: function (x, y, width, height) {
         /** Create a new SVGRect.
         */
-        var r = svgroot.createSVGRect();
+        var r = Svgdom.svgroot.createSVGRect();
         r.x = x;
         r.y = y;
         r.width = width;
@@ -43,10 +45,10 @@ var Svgdom = {
         return r;
     },
 
-    newSVGRect_fromPoints: function (p1, p2, svgroot) {
+    newSVGRect_fromPoints: function (p1, p2) {
         /** Create a new SVGRect.
         */
-        var r = svgroot.createSVGRect();
+        var r = Svgdom.svgroot.createSVGRect();
         r.x = Math.min(p1.x, p2.x);
         r.y = Math.min(p1.y, p2.y);
         r.width = Math.abs(p2.x-p1.x);
@@ -70,17 +72,10 @@ var Svgdom = {
         return Svgdom.newRectElement(r.x, r.y, r.width, r.height);
     },
 
-    epsilonRectAt: function (p, epsilon, somesvgelement) {
-        var svgroot;
+    epsilonRectAt: function (p, epsilon) {
         var debug = false;
-        if (debug) console.log("[epsilonRectAt] p, epsilon, somesvgelement:", p, epsilon, somesvgelement);
-        if          (somesvgelement instanceof SVGSVGElement)   svgroot = somesvgelement;
-        else if     (somesvgelement instanceof SVGElement)      svgroot = somesvgelement.ownerSVGElement;
-        else {
-            if (debug) console.log("[epsilonRectAt] invalid svg elment:", somesvgelement);
-            throw "[epsilonRectAt] Expected an instance of SVGSVGElement or SVGElement.";
-        }
-        var r = svgroot.createSVGRect();
+        if (debug) console.log("[epsilonRectAt] p, epsilon:", p, epsilon);
+        var r = Svgdom.svgroot.createSVGRect();
         r.x = p.x-epsilon;
         r.y = p.y-epsilon;
         r.width = epsilon*2;
@@ -125,7 +120,7 @@ var Svgdom = {
     getCentrePoint: function (circle) {
         /** Returns an SVGPoint at the centre of `circle`.
         */
-        var centre = circle.ownerSVGElement.createSVGPoint()
+        var centre = Svgdom.svgroot.createSVGPoint();
         centre.x = circle.cx.baseVal.value;
         centre.y = circle.cy.baseVal.value;
         return centre;
@@ -134,8 +129,8 @@ var Svgdom = {
     getBothEndsOfLine: function (line) {
         /** Returns an SVGPoint at the endpoint of `line`.
         */
-        var  start = line.ownerSVGElement.createSVGPoint()
-        var  end = line.ownerSVGElement.createSVGPoint()
+        var  start = Svgdom.svgroot.createSVGPoint()
+        var  end = Svgdom.svgroot.createSVGPoint()
         start.x = line.x1.baseVal.value;
         start.y = line.y1.baseVal.value;
         end.x = line.x2.baseVal.value;
@@ -157,7 +152,7 @@ var Svgdom = {
         */
         var debug = false;
         if (path.tagName != "path") throw "[getBothEndsOfPath] expected a path.";
-        var endpoints = [path.ownerSVGElement.createSVGPoint(), path.ownerSVGElement.createSVGPoint()];
+        var endpoints = [Svgdom.svgroot.createSVGPoint(), Svgdom.svgroot.createSVGPoint()];
         var pathdata = path.getAttribute("d").trim();
         if (!pathdata.startsWith("M")) throw ("[getBothEndsOfPath] pathdata should start with M. "+pathdata);
         if (debug) console.log("[GETBOTHENDSOFPATH] pathdata:", pathdata);
@@ -199,9 +194,9 @@ var Svgdom = {
      */
         if (poly.tagName != "polyline") throw "[getBothEndsOfPoly] expected a polyline.";
         var debug = false;
-        var points = [poly.ownerSVGElement.createSVGPoint(),
-                      poly.ownerSVGElement.createSVGPoint(),
-                      poly.ownerSVGElement.createSVGPoint()];
+        var points = [Svgdom.svgroot.createSVGPoint(),
+                      Svgdom.svgroot.createSVGPoint(),
+                      Svgdom.svgroot.createSVGPoint()];
         var pointdata = poly.getAttribute("points");
         if (debug) console.log("[getBothEndsOfPoly] end:", coords);
         var coords = pointdata.trim().split(/[\s,]+/);

--- a/js/svgretrieve.js
+++ b/js/svgretrieve.js
@@ -23,10 +23,15 @@
 "use strict";
 
 var Svgretrieve = {
+    svgroot: undefined,
 
-    enclosingFullHeightStripe: function(line, svgcontainer) {
+    init: function (svgroot) {
+        Svgretrieve.svgroot = svgroot;
+    },
+
+    enclosingFullHeightStripe: function(line) {
         /*  Determine the horizontal boundaries enclosing `line`.
-            Return a full-height vertical stripe/rectangle (from top to bottom of `svgcontainer`) with corresponding horizontal boundaries.
+            Return a full-height vertical stripe/rectangle (from top to bottom of `Svgretrieve.svgroot`) with corresponding horizontal boundaries.
             Initial use case: Select elements potentially affected by a horizontal cut.
         */
         var p1, p2, above, below, stripe, x1, y1, x2, y2, vBy, vBh;
@@ -34,95 +39,95 @@ var Svgretrieve = {
         y1 = line.y1.baseVal.value;
         x2 = line.x2.baseVal.value;
         y2 = line.y2.baseVal.value;
-        vBy = svgcontainer.getAttribute("viewBox").split(" ")[1];
-        vBh = svgcontainer.getAttribute("viewBox").split(" ")[3];
+        vBy = Svgretrieve.svgroot.getAttribute("viewBox").split(" ")[1];
+        vBh = Svgretrieve.svgroot.getAttribute("viewBox").split(" ")[3];
 
-        p1 = svgcontainer.createSVGPoint();
-        p2 = svgcontainer.createSVGPoint();
+        p1 = Svgretrieve.svgroot.createSVGPoint();
+        p2 = Svgretrieve.svgroot.createSVGPoint();
         p1.x = x1;
         p1.y = vBy;
         p2.x = x2;
         p2.y = vBy+vBh;
-        stripe = Svgdom.newSVGRect_fromPoints(p1, p2, svgcontainer);
-        p1 = svgcontainer.createSVGPoint();
-        p2 = svgcontainer.createSVGPoint();
+        stripe = Svgdom.newSVGRect_fromPoints(p1, p2);
+        p1 = Svgretrieve.svgroot.createSVGPoint();
+        p2 = Svgretrieve.svgroot.createSVGPoint();
         p1.x = x1;
         p1.y = y1;
         p2.x = x2;
         p2.y = vBy+vBh;
-        above = Svgdom.newSVGRect_fromPoints(p1, p2, svgcontainer);
-        p1 = svgcontainer.createSVGPoint();
-        p2 = svgcontainer.createSVGPoint();
+        above = Svgdom.newSVGRect_fromPoints(p1, p2);
+        p1 = Svgretrieve.svgroot.createSVGPoint();
+        p2 = Svgretrieve.svgroot.createSVGPoint();
         p1.x = x1;
         p1.y = y1;
         p2.x = x2;
         p2.y = vBy;
-        below = Svgdom.newSVGRect_fromPoints(p1, p2, svgcontainer);
+        below = Svgdom.newSVGRect_fromPoints(p1, p2);
         return [stripe, above, below];
     },
 
-    enclosingFullWidthStripe: function(line, svgcontainer) {
+    enclosingFullWidthStripe: function(line) {
         /*  Determine the vertical boundaries enclosing `line`.
-            Return a full-width horizontal stripe/rectangle (from left to right of `svgcontainer`) with corresponding vertical boundaries.
+            Return a full-width horizontal stripe/rectangle (from left to right of `Svgretrieve.svgroot`) with corresponding vertical boundaries.
             Initial use case: Select elements potentially affected by a vertical cut.
         */
         throw "[enclosingFullWidthStripe] not implemented."
     },
 
-    _transformRect_svg2view: function (svgrect, svgroot) {
-        var trafo = svgroot.getCTM();
-        var p1 = svgroot.createSVGPoint();
-        var p2 = svgroot.createSVGPoint();
+    _transformRect_svg2view: function (svgrect) {
+        var trafo = Svgretrieve.svgroot.getCTM();
+        var p1 = Svgretrieve.svgroot.createSVGPoint();
+        var p2 = Svgretrieve.svgroot.createSVGPoint();
         p1.x = svgrect.x;
         p1.y = svgrect.y;
         p2.x = svgrect.x + svgrect.width;
         p2.y = svgrect.y + svgrect.height;
         p1 = p1.matrixTransform(trafo);
         p2 = p2.matrixTransform(trafo);
-        return Svgdom.newSVGRect_fromPoints(p1, p2, svgroot);
+        return Svgdom.newSVGRect_fromPoints(p1, p2);
     },
 
-    getIntersectedElements: function(arearect, svgroot) {
-        return svgroot.getIntersectionList(Svgretrieve._transformRect_svg2view(arearect, svgroot), svgroot);
+    getIntersectedElements: function(arearect) {
+        return Svgretrieve.svgroot.getIntersectionList(Svgretrieve._transformRect_svg2view(arearect), Svgretrieve.svgroot);
     },
-    getEnclosedElements: function(arearect, svgroot) {
-        return svgroot.getEnclosureList(Svgretrieve._transformRect_svg2view(arearect, svgroot), svgroot);
+    getEnclosedElements: function(arearect) {
+        return Svgretrieve.svgroot.getEnclosureList(Svgretrieve._transformRect_svg2view(arearect), Svgretrieve.svgroot);
     },
-    checkIntersected: function(el, arearect, svgroot) {
-        return svgroot.checkIntersection(el, Svgretrieve._transformRect_svg2view(arearect, svgroot));
+    checkIntersected: function(el, arearect) {
+        return Svgretrieve.svgroot.checkIntersection(el, Svgretrieve._transformRect_svg2view(arearect));
     },
-    checkEnclosed: function(el, arearect, svgroot) {
-        return svgroot.checkEnclosure(el, Svgretrieve._transformRect_svg2view(arearect, svgroot));
+    checkEnclosed: function(el, arearect) {
+        return Svgretrieve.svgroot.checkEnclosure(el, Svgretrieve._transformRect_svg2view(arearect));
     },
 
-    getCirclesAt: function(c, r1, r2, svgcontainer) {
+    getCirclesAt: function(c, r1, r2) {
         /** Return all circles roughly centred at `c` with a radius `r1 < radius < r2` (approximately).
         */
         var debug = false;
-        if (debug) console.log("[GETCIRCLESAT] c, r1, r2, svgcontainer:", c, r1, r2, svgcontainer);
+        if (debug) console.log("[GETCIRCLESAT] c, r1, r2:", c, r1, r2);
         if (parseFloat(r1) >= parseFloat(r2)) throw  "[getCirclesAt] expected r1 < r2.";
         var epsilon = r2/100;   // small width compared to the larger radius
         var candidates;         // A list of candidate circles
         var confirmed = [];     // confirmed circles (hit by all test areas)
         var testareas = [
-            Svgdom.newSVGRect (c.x-epsilon, c.y-parseFloat(r2), 2*epsilon, r2-parseFloat(r1), svgcontainer),  // "north"
-            Svgdom.newSVGRect (c.x-epsilon, c.y+parseFloat(r1), 2*epsilon, r2-parseFloat(r1), svgcontainer),  // "south"
-            Svgdom.newSVGRect (c.x-parseFloat(r2), c.y-epsilon, r2-parseFloat(r1), 2*epsilon, svgcontainer),  // "west"
-            Svgdom.newSVGRect (c.x+parseFloat(r1), c.y-epsilon, r2-parseFloat(r1), 2*epsilon, svgcontainer),  // "east"
+            Svgdom.newSVGRect (c.x-epsilon, c.y-parseFloat(r2), 2*epsilon, r2-parseFloat(r1)),  // "north"
+            Svgdom.newSVGRect (c.x-epsilon, c.y+parseFloat(r1), 2*epsilon, r2-parseFloat(r1)),  // "south"
+            Svgdom.newSVGRect (c.x-parseFloat(r2), c.y-epsilon, r2-parseFloat(r1), 2*epsilon),  // "west"
+            Svgdom.newSVGRect (c.x+parseFloat(r1), c.y-epsilon, r2-parseFloat(r1), 2*epsilon),  // "east"
             ];     // Areas which should all be hit, for a circle to be confirmed
         if (debug) {
             for (var j = 0; j < testareas.length; j++) {
                 console.log("[getCirclesAt]", testareas[j]);
-                var r = Svgdom.addRectElement_SVGRect(svgcontainer, testareas[j]);
+                var r = Svgdom.addRectElement_SVGRect(Svgretrieve.svgroot, testareas[j]);
                 r.setAttribute("fill", "#ffff22");
             }
         }
-        candidates = Svgretrieve.getIntersectedElements(testareas[0], svgcontainer);
+        candidates = Svgretrieve.getIntersectedElements(testareas[0]);
         for (var i = 0; i < candidates.length; i++) {
             if (candidates[i] instanceof SVGCircleElement) {
                 var reject = false;     // reject the currently tested candidate?
                 for (var j = 1; j < testareas.length; j++) {
-                    if ( ! Svgretrieve.checkIntersected(candidates[i], testareas[j], svgcontainer) ) {
+                    if ( ! Svgretrieve.checkIntersected(candidates[i], testareas[j]) ) {
                         reject = true;
                         break;
                     }
@@ -133,32 +138,32 @@ var Svgretrieve = {
         return confirmed;
     },
 
-    getLinesFromTo: function(p1, p2, epsilon, svgcontainer) {
+    getLinesFromTo: function(p1, p2, epsilon) {
         /** Return all lines roughly connecting points `p1`, `p2`.
         */
         var debug = false;
-        if (debug) console.log("[GETLINESFROMTO] p1, p2, svgcontainer:", p1, p2, svgcontainer);
+        if (debug) console.log("[GETLINESFROMTO] p1, p2:", p1, p2);
 
         var candidates;         // A list of candidate lines starting at `p1`
         var confirmed = [];     // confirmed lines (other endpoint at `p2`)
         var testareas = [
-            Svgdom.epsilonRectAt(p1, epsilon, svgcontainer),
-            Svgdom.epsilonRectAt(p2, epsilon, svgcontainer),
+            Svgdom.epsilonRectAt(p1, epsilon),
+            Svgdom.epsilonRectAt(p2, epsilon),
             ];     // Areas which should all be hit
         if (debug) {
             for (var j = 0; j < testareas.length; j++) {
                 console.log("[getLinesFromTo]", testareas[j]);
-                var r = Svgdom.addRectElement_SVGRect(svgcontainer, testareas[j]);
+                var r = Svgdom.addRectElement_SVGRect(Svgretrieve.svgroot, testareas[j]);
                 r.setAttribute("fill", "#ffff22");
             }
         }
-        candidates = Svgretrieve.getIntersectedElements(testareas[0], svgcontainer);
+        candidates = Svgretrieve.getIntersectedElements(testareas[0]);
         if (debug) console.log("[getLinesFromTo] candidates", candidates);
         for (var i = 0; i < candidates.length; i++) {
             if (candidates[i] instanceof SVGLineElement) {
                 var reject = false;     // reject the currently tested candidate?
                 for (var j = 1; j < testareas.length; j++) {
-                    if ( ! Svgretrieve.checkIntersected(candidates[i], testareas[j], svgcontainer) ) {
+                    if ( ! Svgretrieve.checkIntersected(candidates[i], testareas[j]) ) {
                         reject = true;
                         break;
                     }
@@ -168,5 +173,4 @@ var Svgretrieve = {
         }
         return confirmed;
     },
-
 }

--- a/spec/spec_DOMrefsheet.js
+++ b/spec/spec_DOMrefsheet.js
@@ -182,12 +182,14 @@ function addTest_selectionset(reftestElement, p0x, p0y, color) {
         expect(proc.classList).toContain("testDOM");
         var svgroot = proc.firstElementChild;
         expect(svgroot).toBeElement();
+        Svgdom.init(svgroot);
+        Svgretrieve.init(svgroot);
         var p0 = svgroot.createSVGPoint();
         p0.x = p0x;
         p0.y = p0y;
-        var arearect = Svgdom.epsilonRectAt(p0, epsilon, svgroot);
+        var arearect = Svgdom.epsilonRectAt(p0, epsilon);
         Clip8.blocklist = [];   // reset the blocklist; we are fetching a new instruction
-        var sel = Svgretrieve.getIntersectedElements(arearect, svgroot);
+        var sel = Svgretrieve.getIntersectedElements(arearect);
         var S = []
         for ( var i = 0; i < Clip8.TAGS.length; i++ ) S.push([]);
         for ( var i = 0; i < sel.length; i++ )

--- a/spec/spec_DOMrefsheet.js
+++ b/spec/spec_DOMrefsheet.js
@@ -1,6 +1,10 @@
 
 var CLIP8_RUNNINGTIME = 500
 
+// For normal test runs, the test sheet specifies an expected number of `cycles`
+// The test allows the clip8 interpreter to run for `cycles + EXCESS_CYCLES`.
+var EXCESS_CYCLES = 100         
+
 var customMatchers = {
 
 toBeElement:
@@ -132,7 +136,11 @@ function addTest_normal_execution(reftestElement, cycles) {
         expect(svgroot.id).toBe("");
         svgroot.setAttributeNS(null,"id", "clip8svgroot");
         expect(svgroot.id).toBe("clip8svgroot");
-        expect(Clip8.envokeOperation).not.toThrow();
+        expect(
+            function () {
+                Clip8controler.init(svgroot, visualise=false);
+                Clip8controler.testRun(cycles+EXCESS_CYCLES);
+            }).not.toThrow();
         jasmine.clock().tick(CLIP8_RUNNINGTIME);
         expect(Clip8.executeOneOperation).toHaveBeenCalled();
         expect(Clip8.executeOneOperation.calls.count()).toEqual(cycles, "(instruction of cycles)");


### PR DESCRIPTION
`Svgdom` and `Svgretrieve` now receive a pointer to the svg root element via `init` method, once.