### PR TITLE
Element detection independent of whether `style` or attributes define elements' appearance.

### DIFF
--- a/js/clip8.js
+++ b/js/clip8.js
@@ -495,8 +495,7 @@ var Clip8 = {
             }
             else if (I0[Clip8.POLYLINETAG].length == 0 && I0[Clip8.RECTTAG].length == 0) {
                 // MOVE-REL, CUT, DEL
-                // FIXME: clarify use of style vs attribute
-                if (theline.getAttribute("stroke-dasharray")) {
+                if ( ISCD.getExplicitProperty(theline, 'stroke-dasharray') ) {
                     if (debug) console.log("one dashed line.");
                     // CUT, DEL
                     var linedir = Clip8decode.directionOfSVGLine(theline, epsilon, minlen);

--- a/js/clip8.js
+++ b/js/clip8.js
@@ -212,8 +212,9 @@ var Clip8 = {
             return undefined;
         }
         if (debug) console.log("[selectedElementSet] selector from selectorcore:", s);
-        // FIXME: clarify use of style vs attribute
-        var dashes = selectorcore[0].getAttribute("stroke-dasharray").split(",").map(parseFloat);;
+        var dashes = window.getComputedStyle(selectorcore[0])
+                           .getPropertyValue('stroke-dasharray')
+                           .split(",").map(parseFloat);
         if (dashes.length == 2 && dashes[0] < dashes[1] )
             return Svgretrieve.getEnclosedRectangles(s);
         else if (dashes.length == 2 && dashes[0] > dashes[1] )

--- a/js/clip8.js
+++ b/js/clip8.js
@@ -57,8 +57,7 @@ var Clip8 = {
     },
 
     _deriveToleranceFromElementStroke: function (el) {
-        // FIXME: clarify use of style vs attribute
-        var tolerance = el.getAttribute("stroke-width") * Clip8.STROKE_TOLERANCE_RATIO;
+        var tolerance = ISCD.getExplicitProperty(el, 'stroke-width') * Clip8.STROKE_TOLERANCE_RATIO;
         if (! tolerance) {
             console.warn("Could not derive tolerance from stroke width.", el);
             tolerance = 1.0 * Clip8.STROKE_TOLERANCE_RATIO;

--- a/js/clip8.js
+++ b/js/clip8.js
@@ -82,16 +82,13 @@ var Clip8 = {
     },
 
     _hightlightElementColour: function(el, colourtag) {
-        // FIXME: clarify use of style vs attribute
-        var old = el.getAttribute("stroke");
-        el.setAttribute("stroke",  colourtag);
-        Clip8.highlighted.push({el: el, origstroke: old});
+        Clip8.highlighted.push({el: el, origstroke: el.style.getPropertyValue('stroke')});
+        el.style.setProperty('stroke', colourtag);
     },
 
     _clearHighlight: function() {
         for (var i = 0; i < Clip8.highlighted.length; i++) {
-            // FIXME: clarify use of style vs attribute
-            Clip8.highlighted[i].el.setAttribute("stroke", Clip8.highlighted[i].origstroke);
+            Clip8.highlighted[i].el.style.setProperty('stroke', Clip8.highlighted[i].origstroke);
         }
     },
 

--- a/js/clip8.js
+++ b/js/clip8.js
@@ -111,11 +111,8 @@ var Clip8 = {
             for (var i=0; i<locations.length; i++) {
                 console.error (locations[i]);
                 if (Clip8.highlightErr) {
-                    // FIXME: clarify use of style vs attribute
                     locrect = Svgdom.newRectElement(locations[i].x-5, locations[i].y-5, 10, 10);
-                    locrect.setAttribute('fill', "none");
-                    locrect.setAttribute('stroke', "#ee22cc");
-                    locrect.setAttribute('stroke-width', "1");
+                    locrect.style = "fill:none; stroke:#ee22cc; stroke-width: 1";
                     Clip8.svgroot.appendChild (locrect);
                 }
             }

--- a/js/clip8.js
+++ b/js/clip8.js
@@ -646,8 +646,13 @@ var Clip8controler = {
         catch (exc) {
             console.log("Hint:", exc);
             Clip8controler._stopTimer();
-            Clip8controler.erroroutput.appendChild(document.createTextNode(exc.error));
-            Clip8controler.hintoutput.appendChild(document.createTextNode(exc.hint));
+            if (exc.error && exc.hint) {
+                Clip8controler.erroroutput.appendChild(document.createTextNode(exc.error));
+                Clip8controler.hintoutput.appendChild(document.createTextNode(exc.hint));
+            } else {
+                Clip8controler.erroroutput.appendChild(document.createTextNode("unexpected error!"));
+                Clip8controler.hintoutput.appendChild(document.createTextNode(exc));
+            }
             Clip8controler.state = Clip8controler.ERROR;
             console.log("ERROR-state.", exc);
         }

--- a/js/clip8.js
+++ b/js/clip8.js
@@ -322,17 +322,13 @@ var Clip8 = {
     initControlFlow: function () {
         var debug = false;
         if (debug) console.log("[initControlFlow]")
-        var debugcolour = false;
         var circles = Clip8.svgroot.getElementsByTagName("circle");
         var centres_offilled = [];  // Centres of filled circles (candidates).
         var radii_offilled = [];    // and their respective radius
         var initialflow = null;
 
         for (var i = 0, c; i < circles.length; i++) {
-            // FIXME: clarify use of style vs attribute
-            if (debugcolour) circles[i].setAttribute("stroke", "#95C9EF");
-            if (circles[i].getAttribute("fill", "none") != "none") {
-                if (debugcolour) circles[i].setAttribute("fill", "#3EA3ED");
+            if ( ISCD.getExplicitProperty(circles[i], 'fill') ) {
                 centres_offilled.push(Svgdom.getCentrePoint(circles[i]));
                 radii_offilled.push(Svgdom.getRadius(circles[i]));
             }
@@ -364,9 +360,6 @@ var Clip8 = {
                     Clip8._reportError("initControlFlow", "Failed to identify intial path segment.", candidates, [centres_offilled[i]],
                                        "An intitial element was found but there seems to be no control flow path close enough to its centre. If there are candidates nearby they are highlighted in red: Try using snap in your SVG editor to increase drawing precision.");
                 }
-
-                // FIXME: clarify use of style vs attribute
-                if (debugcolour) hitlist[0].setAttribute("stroke", "#ED1E79");
                 Clip8.pminus1_point = centres_offilled[i];
                 if (Clip8.visualiseIP) Clip8._highlightElement(hitlist[0]);
                 return hitlist[0];

--- a/js/clip8.js
+++ b/js/clip8.js
@@ -57,6 +57,7 @@ var Clip8 = {
     },
 
     _deriveToleranceFromElementStroke: function (el) {
+        // FIXME: clarify use of style vs attribute
         var tolerance = el.getAttribute("stroke-width") * Clip8.STROKE_TOLERANCE_RATIO;
         if (! tolerance) {
             console.warn("Could not derive tolerance from stroke width.", el);
@@ -81,6 +82,7 @@ var Clip8 = {
     },
 
     _hightlightElementColour: function(el, colourtag) {
+        // FIXME: clarify use of style vs attribute
         var old = el.getAttribute("stroke");
         el.setAttribute("stroke",  colourtag);
         Clip8.highlighted.push({el: el, origstroke: old});
@@ -88,6 +90,7 @@ var Clip8 = {
 
     _clearHighlight: function() {
         for (var i = 0; i < Clip8.highlighted.length; i++) {
+            // FIXME: clarify use of style vs attribute
             Clip8.highlighted[i].el.setAttribute("stroke", Clip8.highlighted[i].origstroke);
         }
     },
@@ -111,6 +114,7 @@ var Clip8 = {
             for (var i=0; i<locations.length; i++) {
                 console.error (locations[i]);
                 if (Clip8.highlightErr) {
+                    // FIXME: clarify use of style vs attribute
                     locrect = Svgdom.newRectElement(locations[i].x-5, locations[i].y-5, 10, 10);
                     locrect.setAttribute('fill', "none");
                     locrect.setAttribute('stroke', "#ee22cc");
@@ -214,6 +218,7 @@ var Clip8 = {
             return undefined;
         }
         if (debug) console.log("[selectedElementSet] selector from selectorcore:", s);
+        // FIXME: clarify use of style vs attribute
         var dashes = selectorcore[0].getAttribute("stroke-dasharray").split(",").map(parseFloat);;
         if (dashes.length == 2 && dashes[0] < dashes[1] )
             return Svgretrieve.getEnclosedRectangles(s);
@@ -329,6 +334,7 @@ var Clip8 = {
         var initialflow = null;
 
         for (var i = 0, c; i < circles.length; i++) {
+            // FIXME: clarify use of style vs attribute
             if (debugcolour) circles[i].setAttribute("stroke", "#95C9EF");
             if (circles[i].getAttribute("fill", "none") != "none") {
                 if (debugcolour) circles[i].setAttribute("fill", "#3EA3ED");
@@ -364,7 +370,7 @@ var Clip8 = {
                                        "An intitial element was found but there seems to be no control flow path close enough to its centre. If there are candidates nearby they are highlighted in red: Try using snap in your SVG editor to increase drawing precision.");
                 }
 
-
+                // FIXME: clarify use of style vs attribute
                 if (debugcolour) hitlist[0].setAttribute("stroke", "#ED1E79");
                 Clip8.pminus1_point = centres_offilled[i];
                 if (Clip8.visualiseIP) Clip8._highlightElement(hitlist[0]);
@@ -501,6 +507,7 @@ var Clip8 = {
             }
             else if (I0[Clip8.POLYLINETAG].length == 0 && I0[Clip8.RECTTAG].length == 0) {
                 // MOVE-REL, CUT, DEL
+                // FIXME: clarify use of style vs attribute
                 if (theline.getAttribute("stroke-dasharray")) {
                     if (debug) console.log("one dashed line.");
                     // CUT, DEL

--- a/js/clip8.js
+++ b/js/clip8.js
@@ -646,7 +646,7 @@ var Clip8controler = {
         catch (exc) {
             console.log("Hint:", exc);
             Clip8controler._stopTimer();
-            if (exc.error && exc.hint) {
+            if (exc.error) {
                 Clip8controler.erroroutput.appendChild(document.createTextNode(exc.error));
                 Clip8controler.hintoutput.appendChild(document.createTextNode(exc.hint));
             } else {

--- a/js/svgdom.js
+++ b/js/svgdom.js
@@ -19,6 +19,8 @@
 
 "use strict";
 
+/** Processes single SVG elements and their geometric aspects in the DOM
+*/
 var Svgdom = {
     svgroot: undefined,
     SVGNS: undefined,

--- a/js/svgretrieve.js
+++ b/js/svgretrieve.js
@@ -369,6 +369,18 @@ var ISCD = {
         }
     },
 
+    /** Checks if a property is explicitly assigned to an element.
+        The idea is to return exactly the visually effective properties; such as a visible stroke.
+        If it is not set or `none` the return value is "".
+    */
+    getExplicitProperty: function (el, property) {
+        var computedStyle = window.getComputedStyle(el);
+        if (computedStyle != "none")
+            return computedStyle;
+        else
+            return "";
+    },
+
     detect: function(el) {
         if (ISCD.verbose) console.log("[ISCD.detect]", el);
         var computedStyle = window.getComputedStyle(el);

--- a/js/svgretrieve.js
+++ b/js/svgretrieve.js
@@ -16,8 +16,8 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-
-/** Derive `SVGRect` instances based on relevant geometric properties of SVG DOM elements.
+/** Detect, classify, register and retrieve (multiple) SVG elements based on their
+    tag, style, location or other spatial properties.
 */
 
 "use strict";
@@ -53,6 +53,7 @@ var Svgretrieve = {
     // classifies them generically, assuming any SVG element.
     // For testing and code legibility I decided to stick with it for now.
     registerElements_fromDOM () {
+        var debug = false;
         Svgretrieve.I_collection = new kdTree([], Svgdom.euclidDistance, ["x", "y"]);
         Svgretrieve.S_collection = new kdTree([], Svgdom.euclidDistance, ["x", "y"]);
         Svgretrieve.C_collection = new kdTree([], Svgdom.euclidDistance, ["x", "y"]);
@@ -85,6 +86,7 @@ var Svgretrieve = {
                                  Svgretrieve.rect_intervals, elems);
         // CIRCLE
         elems = Svgretrieve.clip8root.getElementsByTagName("circle");
+        if (debug) console.debug("CIRCLE elements:", elems);
         for (var i=0; i<elems.length; i++) {
             if (ISCD.detect(elems[i]) == ISCD.CONTROLFLOW) {
                 cpt = Svgdom.getCentrePoint(elems[i]);
@@ -97,6 +99,7 @@ var Svgretrieve = {
         }
         // PATH
         elems = Svgretrieve.clip8root.getElementsByTagName("path");
+        if (debug) console.debug("PATH elements:", elems);
         for (var i=0; i<elems.length; i++) {
             try {
                 cpts = Svgdom.getBothEndsOfPath(elems[i]);
@@ -126,6 +129,7 @@ var Svgretrieve = {
         }
         // LINE
         elems = Svgretrieve.clip8root.getElementsByTagName("line");
+        if (debug) console.debug("LINE elements:", elems);
         for (var i=0; i<elems.length; i++) {
             switch(ISCD.detect(elems[i])) {
                 case ISCD.INSTRUCTION:
@@ -158,6 +162,7 @@ var Svgretrieve = {
         }
         // POLYLINE
         elems = Svgretrieve.clip8root.getElementsByTagName("polyline");
+        if (debug) console.debug("POLYLINE elements:", elems);
         for (var i=0; i<elems.length; i++) {
             switch(ISCD.detect(elems[i])) {
                 case ISCD.INSTRUCTION:
@@ -181,6 +186,7 @@ var Svgretrieve = {
             }
         }
         console.groupEnd();
+        if (debug) console.log("unreg el: ", unreg);
         if (unreg.len > 0) console.warn("there were unregistered elements:", unreg);
         if (Svgretrieve.highlight_unregistered)
             unreg.forEach(function (el) { Svgretrieve.highlighterFn(el, Svgretrieve.UNREGISTERED_COLOUR) } );
@@ -336,7 +342,7 @@ var Svgretrieve = {
 
 var ISCD = {
     debug       : false,
-    verbose     : true,
+    verbose     : false,
     INVALID     : 0,
     INSTRUCTION : 1,
     SELECTOR    : 2,

--- a/js/svgretrieve.js
+++ b/js/svgretrieve.js
@@ -375,8 +375,8 @@ var ISCD = {
     */
     getExplicitProperty: function (el, property) {
         var computedStyle = window.getComputedStyle(el);
-        if (computedStyle != "none")
-            return computedStyle;
+        if (computedStyle.getPropertyValue(property) != "none")
+            return computedStyle.getPropertyValue(property);
         else
             return "";
     },

--- a/js/svgretrieve.js
+++ b/js/svgretrieve.js
@@ -26,7 +26,7 @@ var Svgretrieve = {
     highlight_unregistered: false,
     highlight_isc: false,
     highlighterFn: undefined,
-    UNREGISTERED_COLOUR: "#ff1111",
+    UNREGISTERED_COLOUR: "#ffff88",
     INSCTRUCTION_COLOUR: "#ffffff",
     SELECTOR_COLOUR: "#C97A4F",
     CONTROLFLOW_COLOUR: "#9BC9C7",

--- a/js/svgretrieve.js
+++ b/js/svgretrieve.js
@@ -186,8 +186,7 @@ var Svgretrieve = {
             }
         }
         console.groupEnd();
-        if (debug) console.log("unreg el: ", unreg);
-        if (unreg.len > 0) console.warn("there were unregistered elements:", unreg);
+        if (unreg.length > 0) console.warn("there were unregistered elements:", unreg);
         if (Svgretrieve.highlight_unregistered)
             unreg.forEach(function (el) { Svgretrieve.highlighterFn(el, Svgretrieve.UNREGISTERED_COLOUR) } );
     },
@@ -342,7 +341,7 @@ var Svgretrieve = {
 
 var ISCD = {
     debug       : false,
-    verbose     : false,
+    verbose     : true,
     INVALID     : 0,
     INSTRUCTION : 1,
     SELECTOR    : 2,
@@ -371,7 +370,7 @@ var ISCD = {
     },
 
     detect: function(el) {
-        if (ISCD.debug) console.log("[ISCD] element, tagName", el, el.tagName);
+        if (ISCD.verbose) console.log("[ISCD.detect]", el);
         var computedStyle = window.getComputedStyle(el);
         if (ISCD.debug) console.log("----computedStyle", computedStyle);
         // See `tree-of-graphics-elements.pdf` for an overview of graphics element detection.

--- a/usability/inkskape_fromscratch1-onemove.svg
+++ b/usability/inkskape_fromscratch1-onemove.svg
@@ -10,11 +10,11 @@
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="400"
-   height="400"
-   viewBox="0 0 400 400"
+   height="300"
+   viewBox="0 0 400 300"
    id="svg2"
    version="1.1"
-   inkscape:version="0.91 r13725"
+   inkscape:version="0.92.1 r15371"
    sodipodi:docname="inkskape_fromscratch1-onemove.svg">
   <metadata
      id="metadata4388">
@@ -39,33 +39,34 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1875"
-     inkscape:window-height="1056"
+     inkscape:window-width="1920"
+     inkscape:window-height="1013"
      id="namedview4384"
      showgrid="false"
-     inkscape:zoom="0.2871875"
-     inkscape:cx="-394.86097"
-     inkscape:cy="435.57025"
-     inkscape:window-x="45"
-     inkscape:window-y="24"
+     inkscape:zoom="1.6245778"
+     inkscape:cx="153.41546"
+     inkscape:cy="163.17748"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2" />
   <g
-     id="g4374" />
+     id="g4374"
+     transform="translate(0,-100)" />
   <circle
      style="fill:#217867;fill-rule:evenodd;stroke:#217867;stroke-width:0.48780489px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
      id="path3336"
-     cx="69.767319"
-     cy="154.39651"
+     cx="55.839134"
+     cy="85.734924"
      r="9.7560978" />
   <path
      style="fill:none;fill-rule:evenodd;stroke:#217867;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="m 69.767318,154.39652 c 60.564772,43.2768 152.741192,33.68036 152.741192,33.68036 l 0,0"
+     d="M 55.839135,85.734931 C 116.40391,129.01173 208.58033,119.41529 208.58033,119.41529 v 0"
      id="path3340"
      inkscape:connector-curvature="0" />
   <path
      style="fill:none;fill-rule:evenodd;stroke:#217867;stroke-width:5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="m 222.50851,188.07688 -44.9891,78.83981"
+     d="m 208.58033,119.41529 -44.9891,78.83981"
      id="path4144"
      inkscape:connector-curvature="0" />
   <rect
@@ -73,30 +74,30 @@
      id="rect4165"
      width="54.005848"
      height="71.672913"
-     x="222.50851"
-     y="116.40397" />
+     x="208.58034"
+     y="47.742378" />
   <path
      style="fill:none;fill-rule:evenodd;stroke:#217867;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="M 325.71466,305.60446 C 302.496,234.88056 222.50851,188.07688 222.50851,188.07688 l 0,0"
+     d="M 311.78648,236.94287 C 288.56782,166.21897 208.58033,119.41529 208.58033,119.41529 v 0"
      id="path3340-3"
      inkscape:connector-curvature="0" />
   <circle
      style="fill:#217867;fill-rule:evenodd;stroke:#217867;stroke-width:0.48780489px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
      id="path3336-6"
-     cx="325.71466"
-     cy="305.60446"
+     cx="311.78647"
+     cy="236.94287"
      r="9.7560978" />
   <circle
      style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#217867;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
      id="path3336-6-7"
-     cx="325.71466"
-     cy="305.60446"
+     cx="311.78647"
+     cy="236.94287"
      r="14.437292" />
   <rect
      style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
      id="rect4259"
      width="24.748737"
      height="44.446712"
-     x="236.61334"
-     y="128.52579" />
+     x="222.68517"
+     y="59.864197" />
 </svg>

--- a/usability/inkskape_fromscratch1-onemove.svg
+++ b/usability/inkskape_fromscratch1-onemove.svg
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="400"
+   height="400"
+   viewBox="0 0 400 400"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="inkskape_fromscratch1-onemove.svg">
+  <metadata
+     id="metadata4388">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4386" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1875"
+     inkscape:window-height="1056"
+     id="namedview4384"
+     showgrid="false"
+     inkscape:zoom="0.2871875"
+     inkscape:cx="-394.86097"
+     inkscape:cy="435.57025"
+     inkscape:window-x="45"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     id="g4374" />
+  <circle
+     style="fill:#217867;fill-rule:evenodd;stroke:#217867;stroke-width:0.48780489px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="path3336"
+     cx="69.767319"
+     cy="154.39651"
+     r="9.7560978" />
+  <path
+     style="fill:none;fill-rule:evenodd;stroke:#217867;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 69.767318,154.39652 c 60.564772,43.2768 152.741192,33.68036 152.741192,33.68036 l 0,0"
+     id="path3340"
+     inkscape:connector-curvature="0" />
+  <path
+     style="fill:none;fill-rule:evenodd;stroke:#217867;stroke-width:5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 222.50851,188.07688 -44.9891,78.83981"
+     id="path4144"
+     inkscape:connector-curvature="0" />
+  <rect
+     style="fill:none;stroke:#217867;stroke-width:3;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:9, 3;stroke-dashoffset:0"
+     id="rect4165"
+     width="54.005848"
+     height="71.672913"
+     x="222.50851"
+     y="116.40397" />
+  <path
+     style="fill:none;fill-rule:evenodd;stroke:#217867;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 325.71466,305.60446 C 302.496,234.88056 222.50851,188.07688 222.50851,188.07688 l 0,0"
+     id="path3340-3"
+     inkscape:connector-curvature="0" />
+  <circle
+     style="fill:#217867;fill-rule:evenodd;stroke:#217867;stroke-width:0.48780489px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="path3336-6"
+     cx="325.71466"
+     cy="305.60446"
+     r="9.7560978" />
+  <circle
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#217867;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="path3336-6-7"
+     cx="325.71466"
+     cy="305.60446"
+     r="14.437292" />
+  <rect
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="rect4259"
+     width="24.748737"
+     height="44.446712"
+     x="236.61334"
+     y="128.52579" />
+</svg>


### PR DESCRIPTION
In general, element detection relies on properties that are visible to the user. 
In particular, `getExplicitProperty` returns the `stroke-dasharray` that "can be seen" in the browser. 

+ relies on `window.getComputedStyle` as it makes it independent of how, in detail, the styling was encoded by the SVG editor.
+ for highlighting the elements `style` as it has the highest precedence in rendering the content.:
e.g. ```<circle . . . style="... stroke: #highlightcolour; ..." . . ./>```
