### PR TITLE
Error reporting on loading transformed elements.

### DIFF
--- a/js/clip8.js
+++ b/js/clip8.js
@@ -628,7 +628,20 @@ var Clip8 = {
         Clip8.visualiseIP = visualiseIP;
         Clip8.highlightErr = highlightErr;
         Svgdom.init(svgroot);
-        Svgretrieve.init(svgroot, highlightErr, highlightSyntax, Clip8._hightlightElementColour);
+        try {
+            Svgretrieve.init(svgroot, highlightErr, highlightSyntax, Clip8._hightlightElementColour);
+        }
+        catch(exc) {
+            if (exc.source == "registerElements_fromDOM" && exc.transformed_elements) {
+                Clip8._reportError(exc.source,
+                            "Transformations are not yet supported, sorry :-(",
+                            exc.transformed_elements,
+                            [],
+                            "The SVG code contains elements with transformations (red). Currently, clip_8 cannot process them. Please try to save an SVG without transformations. Depending on the SVG editor, general settings or export options might help.");
+            }
+            else
+                throw exc;
+        }
         Clip8.cyclescounter = 0
         Clip8.svgroot = svgroot;
         return svgroot;
@@ -671,8 +684,8 @@ var Clip8controler = {
                 Clip8controler.hintoutput.appendChild(document.createTextNode(exc.hint));
             } else {
                 Clip8controler.erroroutput.appendChild(document.createTextNode("unexpected error!"));
-                Clip8controler.hintoutput.appendChild(document.createTextNode(exc)
-                                                      +" "+INTERNAL_ERROR_HINT);
+                Clip8controler.hintoutput.appendChild(document.createTextNode(exc
+                                                      +" "+INTERNAL_ERROR_HINT));
             }
             Clip8controler.state = Clip8controler.ERROR;
             console.log("ERROR-state.", exc);
@@ -716,8 +729,8 @@ var Clip8controler = {
                 Clip8controler.hintoutput.appendChild(document.createTextNode(exc.hint));
             } else {
                 Clip8controler.erroroutput.appendChild(document.createTextNode("unexpected error!"));
-                Clip8controler.hintoutput.appendChild(document.createTextNode(exc)
-                                                      +" "+Clip8.INTERNAL_ERROR_HINT);
+                Clip8controler.hintoutput.appendChild(document.createTextNode(exc
+                                                      +" "+Clip8.INTERNAL_ERROR_HINT));
             }
             Clip8controler.state = Clip8controler.ERROR;
             console.log("ERROR-state.", exc);

--- a/js/clip8.js
+++ b/js/clip8.js
@@ -577,7 +577,10 @@ var Clip8 = {
                             selectedelements1[i].parentElement.removeChild(selectedelements1[i]);
                         break;
                     default:
-                        Clip8._reportError("executeOneOperation", "INTERNAL ERROR: Unforeseen line direction in DELETE!", [decodedinstr.primary], [p0], Clip8.INTERNAL_ERROR_HINT);
+                        Clip8._reportError("executeOneOperation", "INTERNAL ERROR: Unforeseen line direction in DELETE!",
+                                           [decodedinstr.primary],
+                                           [p0],
+                                           Clip8.INTERNAL_ERROR_HINT);
                         break;
                 }
                 break;
@@ -714,7 +717,7 @@ var Clip8controler = {
             } else {
                 Clip8controler.erroroutput.appendChild(document.createTextNode("unexpected error!"));
                 Clip8controler.hintoutput.appendChild(document.createTextNode(exc)
-                                                      +" "+INTERNAL_ERROR_HINT);
+                                                      +" "+Clip8.INTERNAL_ERROR_HINT);
             }
             Clip8controler.state = Clip8controler.ERROR;
             console.log("ERROR-state.", exc);

--- a/js/svgdom.js
+++ b/js/svgdom.js
@@ -34,6 +34,15 @@ var Svgdom = {
         return Math.sqrt ( Math.pow(p1.x - p2.x, 2) +  Math.pow(p1.y - p2.y, 2) );
     },
 
+    compareCTMs: function (ctm1, ctm2) {
+        return ( ctm1.a == ctm2.a &&
+                 ctm1.b == ctm2.b &&
+                 ctm1.c == ctm2.c &&
+                 ctm1.d == ctm2.d &&
+                 ctm1.e == ctm2.e &&
+                 ctm1.f == ctm2.f );
+    },
+
     addGroup: function (parentel) {
         var g = document.createElementNS(Svgdom.SVGNS, "g");
         parentel.appendChild(g);

--- a/js/svgdom.js
+++ b/js/svgdom.js
@@ -34,7 +34,7 @@ var Svgdom = {
         return Math.sqrt ( Math.pow(p1.x - p2.x, 2) +  Math.pow(p1.y - p2.y, 2) );
     },
 
-    compareCTMs: function (ctm1, ctm2) {
+    equalCTMs: function (ctm1, ctm2) {
         return ( ctm1.a == ctm2.a &&
                  ctm1.b == ctm2.b &&
                  ctm1.c == ctm2.c &&

--- a/js/svgretrieve.js
+++ b/js/svgretrieve.js
@@ -36,6 +36,23 @@ var Svgretrieve = {
     S_collection: undefined,
     C_collection: undefined,
     rect_intervals: undefined,
+
+    /** Tests whether an element is in an IGNORE subtree.
+        Traverses from `el` to `root` and checks whether the elements id contains "IGNORE"
+    */
+    _excluded: function(el) {
+        var checking = el;
+        while (checking !== Svgretrieve.svgroot) {
+            if ( checking.id.indexOf("IGNORE") != -1 ||
+                 ["defs", "marker"].indexOf(checking.tagName) != -1 ) {
+                console.log("to be ignored:", el, "because of parent:", checking);
+                return true;
+            }
+            checking = checking.parentNode;
+        }
+        return false;
+    },
+
     init: function (svgroot, highlight_unregistered, highlight_isc, highlighterFn) {
         console.log("[Svgretrieve.init]", svgroot, highlight_unregistered, highlight_isc, highlighterFn)
         Svgretrieve.highlight_unregistered = highlight_unregistered;
@@ -46,7 +63,6 @@ var Svgretrieve = {
         if (! Svgretrieve.clip8root) Svgretrieve.clip8root = Svgretrieve.svgroot;
         Svgretrieve.registerElements_fromDOM();
     },
-
 
     // The current implementation has a redundancy in it:
     // First, elements are retrieved by tagName but `ISCD.detect` makes no use of that information but
@@ -93,6 +109,7 @@ var Svgretrieve = {
         elems = Svgretrieve.clip8root.getElementsByTagName("circle");
         if (debug) console.debug("CIRCLE elements:", elems);
         for (var i=0; i<elems.length; i++) {
+            if ( Svgretrieve._excluded(elems[i]) ) continue;
             if (ISCD.detect(elems[i]) == ISCD.CONTROLFLOW) {
                 cpt = Svgdom.getCentrePoint(elems[i]);
                 cpt.ownerelement = elems[i];
@@ -113,6 +130,13 @@ var Svgretrieve = {
         elems = Svgretrieve.clip8root.getElementsByTagName("path");
         if (debug) console.debug("PATH elements:", elems);
         for (var i=0; i<elems.length; i++) {
+            if ( Svgretrieve._excluded(elems[i]) ) continue;
+            if (debug) console.log("CTMs:", elems[i], elems[i].getCTM(), refTrafo);
+                if (!Svgdom.compareCTMs(elems[i].getCTM(), refTrafo)) {
+                    if (debug) console.log("ignore transformed element", elems[i]);
+                    transformed.push(elems[i]);
+                    continue
+                }
             try {
                 cpts = Svgdom.getBothEndsOfPath(elems[i]);
             }
@@ -147,6 +171,13 @@ var Svgretrieve = {
         elems = Svgretrieve.clip8root.getElementsByTagName("line");
         if (debug) console.debug("LINE elements:", elems);
         for (var i=0; i<elems.length; i++) {
+            if ( Svgretrieve._excluded(elems[i]) ) continue;
+            if (debug) console.log("CTMs:", elems[i], elems[i].getCTM(), refTrafo);
+                if (!Svgdom.compareCTMs(elems[i].getCTM(), refTrafo)) {
+                    if (debug) console.log("ignore transformed element", elems[i]);
+                    transformed.push(elems[i]);
+                    continue
+                }
             switch(ISCD.detect(elems[i])) {
                 case ISCD.INSTRUCTION:
                     cpts = Svgdom.getBothEndsOfLine(elems[i]);
@@ -180,6 +211,13 @@ var Svgretrieve = {
         elems = Svgretrieve.clip8root.getElementsByTagName("polyline");
         if (debug) console.debug("POLYLINE elements:", elems);
         for (var i=0; i<elems.length; i++) {
+            if ( Svgretrieve._excluded(elems[i]) ) continue;
+            if (debug) console.log("CTMs:", elems[i], elems[i].getCTM(), refTrafo);
+                if (!Svgdom.compareCTMs(elems[i].getCTM(), refTrafo)) {
+                    if (debug) console.log("ignore transformed element", elems[i]);
+                    transformed.push(elems[i]);
+                    continue
+                }
             switch(ISCD.detect(elems[i])) {
                 case ISCD.INSTRUCTION:
                     cpts = Svgdom.getPointsOfPoly(elems[i]);
@@ -202,6 +240,14 @@ var Svgretrieve = {
             }
         }
         console.groupEnd();
+        if (transformed.length > 0) {
+            console.warn("there were transformed elements:", unreg);
+            throw {
+                source: "registerElements_fromDOM",
+                error: "Found transformed elements.",
+                transformed_elements: transformed,
+                hint: Clip8.INTERNAL_ERROR_HINT };
+        }
         if (unreg.length > 0) console.warn("there were unregistered elements:", unreg);
         if (Svgretrieve.highlight_unregistered)
             unreg.forEach(function (el) { Svgretrieve.highlighterFn(el, Svgretrieve.UNREGISTERED_COLOUR) } );

--- a/js/svgretrieve.js
+++ b/js/svgretrieve.js
@@ -71,13 +71,18 @@ var Svgretrieve = {
             Svgretrieve._getMainInterval = Svginterval.getYIntervalRectElement;
             Svgretrieve._getOrthoInterval = Svginterval.getXIntervalRectElement;
         }
+        var referenceEl = Svgdom.addRect(Svgretrieve.clip8root, 0, 0, 1, 1);
+        var refTrafo = referenceEl.getCTM();
+        if (debug) console.log("Reference Transformation:", refTrafo, referenceEl);
+        Svgretrieve.clip8root.removeChild(referenceEl);
         var elems, cpts, cpt;
 
         console.groupCollapsed("Register SVG graphics elements.");
         // RECT
         Svgretrieve.rect_intervals = new IntervalTree1D([]);         // init interval tree for data rectangles
         var elems = Svgretrieve.clip8root.getElementsByTagName("rect");
-        var unreg = [];
+        var transformed = [];   // elements that could not registered due to a transformation
+        var unreg = [];         // elements that were not registered for unspecific reasons
         for (var i=0; i<elems.length; i++) {
             if ( ! Svgretrieve.registerRectElement(elems[i]) )
                 unreg.push(elems[i]);
@@ -91,7 +96,14 @@ var Svgretrieve = {
             if (ISCD.detect(elems[i]) == ISCD.CONTROLFLOW) {
                 cpt = Svgdom.getCentrePoint(elems[i]);
                 cpt.ownerelement = elems[i];
-                Svgretrieve.C_collection.insert(cpt);
+                if (debug) console.log("CTMs:", elems[i], elems[i].getCTM(), refTrafo);
+                if (Svgdom.compareCTMs(elems[i].getCTM(), refTrafo)) {
+                    Svgretrieve.C_collection.insert(cpt);
+                }
+                else {
+                    if (debug) console.log("ignore transformed element", elems[i]);
+                    transformed.push(elems[i]);
+                }
                 if (Svgretrieve.highlight_isc)
                     Svgretrieve.highlighterFn(elems[i], Svgretrieve.CONTROLFLOW_COLOUR);
             } else

--- a/js/svgretrieve.js
+++ b/js/svgretrieve.js
@@ -114,7 +114,7 @@ var Svgretrieve = {
                 cpt = Svgdom.getCentrePoint(elems[i]);
                 cpt.ownerelement = elems[i];
                 if (debug) console.log("CTMs:", elems[i], elems[i].getCTM(), refTrafo);
-                if (Svgdom.compareCTMs(elems[i].getCTM(), refTrafo)) {
+                if (Svgdom.equalCTMs(elems[i].getCTM(), refTrafo)) {
                     Svgretrieve.C_collection.insert(cpt);
                 }
                 else {
@@ -132,7 +132,7 @@ var Svgretrieve = {
         for (var i=0; i<elems.length; i++) {
             if ( Svgretrieve._excluded(elems[i]) ) continue;
             if (debug) console.log("CTMs:", elems[i], elems[i].getCTM(), refTrafo);
-                if (!Svgdom.compareCTMs(elems[i].getCTM(), refTrafo)) {
+                if (!Svgdom.equalCTMs(elems[i].getCTM(), refTrafo)) {
                     if (debug) console.log("ignore transformed element", elems[i]);
                     transformed.push(elems[i]);
                     continue
@@ -173,7 +173,7 @@ var Svgretrieve = {
         for (var i=0; i<elems.length; i++) {
             if ( Svgretrieve._excluded(elems[i]) ) continue;
             if (debug) console.log("CTMs:", elems[i], elems[i].getCTM(), refTrafo);
-                if (!Svgdom.compareCTMs(elems[i].getCTM(), refTrafo)) {
+                if (!Svgdom.equalCTMs(elems[i].getCTM(), refTrafo)) {
                     if (debug) console.log("ignore transformed element", elems[i]);
                     transformed.push(elems[i]);
                     continue
@@ -213,7 +213,7 @@ var Svgretrieve = {
         for (var i=0; i<elems.length; i++) {
             if ( Svgretrieve._excluded(elems[i]) ) continue;
             if (debug) console.log("CTMs:", elems[i], elems[i].getCTM(), refTrafo);
-                if (!Svgdom.compareCTMs(elems[i].getCTM(), refTrafo)) {
+                if (!Svgdom.equalCTMs(elems[i].getCTM(), refTrafo)) {
                     if (debug) console.log("ignore transformed element", elems[i]);
                     transformed.push(elems[i]);
                     continue

--- a/tutorial/01_MoveBy-relative_a.svg
+++ b/tutorial/01_MoveBy-relative_a.svg
@@ -20,7 +20,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -71,9 +71,9 @@
      inkscape:object-nodes="true"
      inkscape:snap-center="true"
      inkscape:snap-object-midpoints="true"
-     inkscape:zoom="1.4047855"
-     inkscape:cx="573.13559"
-     inkscape:cy="315.71838"
+     inkscape:zoom="0.99333335"
+     inkscape:cx="511.20117"
+     inkscape:cy="325.56063"
      inkscape:window-x="-9"
      inkscape:window-y="-9"
      inkscape:window-maximized="1"
@@ -107,21 +107,6 @@
      cy="139.04337"
      cx="307.07568"
      stroke-miterlimit="10" />
-  <circle
-     style="fill:#000000;stroke:#000000;stroke-width:6;stroke-miterlimit:10"
-     id="circle6876-6"
-     r="12"
-     cy="-139.04337"
-     cx="307.07568"
-     stroke-miterlimit="10"
-     transform="scale(1,-1)" />
-  <rect
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#a6cabe;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-     id="rect7954"
-     width="517.20721"
-     height="600"
-     x="682.79272"
-     y="0" />
   <path
      style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:5.22300005;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      d="M 39.813931,210.73338 C 46.75317,291.38166 179.1746,322.71887 303.81393,354.58636 v 0"
@@ -142,80 +127,98 @@
      y1="354.57834"
      x1="303.814"
      stroke-miterlimit="10" />
-  <text
-     xml:space="preserve"
-     style="font-style:normal;font-weight:normal;font-size:21.33333397px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     x="696.64429"
-     y="36.241608"
-     id="text4519"><tspan
-       sodipodi:role="line"
-       id="tspan4517"
+  <g
+     id="instruction_IGNORE"
+     inkscape:label="#g4576">
+    <rect
+       y="0"
+       x="682.79272"
+       height="600"
+       width="517.20721"
+       id="rect7954"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#a6cabe;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+    <text
+       id="text4519"
+       y="36.241608"
        x="696.64429"
-       y="36.241608">How to move things...</tspan></text>
-  <text
-     xml:space="preserve"
-     style="font-style:normal;font-weight:normal;font-size:32px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     x="694.82135"
-     y="130.60403"
-     id="text4523"><tspan
-       sodipodi:role="line"
-       x="694.82135"
+       style="font-style:normal;font-weight:normal;font-size:21.33333397px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       xml:space="preserve"><tspan
+         y="36.241608"
+         x="696.64429"
+         id="tspan4517"
+         sodipodi:role="line">How to move things...</tspan></text>
+    <text
+       id="text4523"
        y="130.60403"
-       id="tspan4547">Change the upper-right</tspan><tspan
-       sodipodi:role="line"
        x="694.82135"
-       y="170.60403"
-       id="tspan4553">end of the green line.</tspan></text>
-  <text
-     xml:space="preserve"
-     style="font-style:normal;font-weight:normal;font-size:21.33333397px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     x="696.9151"
-     y="527.67151"
-     id="text4527"><tspan
-       sodipodi:role="line"
-       x="696.9151"
+       style="font-style:normal;font-weight:normal;font-size:32px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       xml:space="preserve"><tspan
+         id="tspan4547"
+         y="130.60403"
+         x="694.82135"
+         sodipodi:role="line">Change the upper-right</tspan><tspan
+         id="tspan4553"
+         y="170.60403"
+         x="694.82135"
+         sodipodi:role="line">end of the green line.</tspan></text>
+    <text
+       id="text4527"
        y="527.67151"
-       id="tspan4557">Try to make the lower-left corner </tspan><tspan
-       sodipodi:role="line"
        x="696.9151"
-       y="554.3382"
-       id="tspan4563">of the black box land here.</tspan></text>
-  <g
-     id="g4903"
-     transform="translate(0,20)">
-    <path
-       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-       d="m 624.43164,551.16016 v 2 h 126.8457 v -2 z"
-       id="path4561"
-       inkscape:connector-curvature="0" />
-    <path
-       d="m 634.89421,557.00155 -13.11106,-4.82126 13.11106,-4.82127 c -2.0946,2.84647 -2.08253,6.74094 0,9.64253 z"
-       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.75;stroke-linejoin:round;stroke-opacity:1"
-       id="path4909"
-       inkscape:connector-curvature="0" />
-  </g>
-  <text
-     xml:space="preserve"
-     style="font-style:normal;font-weight:normal;font-size:21.33333397px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     x="689.48157"
-     y="292.32388"
-     id="text4527-4"><tspan
-       sodipodi:role="line"
-       x="689.48157"
+       style="font-style:normal;font-weight:normal;font-size:21.33333397px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       xml:space="preserve"><tspan
+         id="tspan4557"
+         y="527.67151"
+         x="696.9151"
+         sodipodi:role="line">Try to make the lower-left corner </tspan><tspan
+         id="tspan4563"
+         y="554.3382"
+         x="696.9151"
+         sodipodi:role="line">of the black box land here.</tspan></text>
+    <g
+       transform="translate(0,20)"
+       id="g4903">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4561"
+         d="m 624.43164,551.16016 v 2 h 126.8457 v -2 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4909"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.75;stroke-linejoin:round;stroke-opacity:1"
+         d="m 634.89421,557.00155 -13.11106,-4.82126 13.11106,-4.82127 c -2.0946,2.84647 -2.08253,6.74094 0,9.64253 z" />
+    </g>
+    <text
+       id="text4527-4"
        y="292.32388"
-       id="tspan4563-6">Only change only this end.</tspan></text>
-  <g
-     transform="translate(-7.4335582,-281.34761)"
-     id="g4903-1">
-    <path
-       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-       d="m 624.43164,551.16016 v 2 h 126.8457 v -2 z"
-       id="path4561-5"
-       inkscape:connector-curvature="0" />
-    <path
-       d="m 634.89421,557.00155 -13.11106,-4.82126 13.11106,-4.82127 c -2.0946,2.84647 -2.08253,6.74094 0,9.64253 z"
-       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.75;stroke-linejoin:round;stroke-opacity:1"
-       id="path4909-3"
-       inkscape:connector-curvature="0" />
+       x="689.48157"
+       style="font-style:normal;font-weight:normal;font-size:21.33333397px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       xml:space="preserve"><tspan
+         id="tspan4563-6"
+         y="292.32388"
+         x="689.48157"
+         sodipodi:role="line">Only change only this end.</tspan></text>
+    <g
+       id="g4903-1"
+       transform="translate(-7.4335582,-281.34761)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4561-5"
+         d="m 624.43164,551.16016 v 2 h 126.8457 v -2 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4909-3"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.75;stroke-linejoin:round;stroke-opacity:1"
+         d="m 634.89421,557.00155 -13.11106,-4.82126 13.11106,-4.82127 c -2.0946,2.84647 -2.08253,6.74094 0,9.64253 z" />
+    </g>
   </g>
+  <circle
+     style="fill:#000000;stroke:#000000;stroke-width:6;stroke-miterlimit:10"
+     id="circle6876-4"
+     r="12"
+     cy="139.04337"
+     cx="307.07568"
+     stroke-miterlimit="10" />
 </svg>

--- a/tutorial/01_MoveBy-relative_a_solution.svg
+++ b/tutorial/01_MoveBy-relative_a_solution.svg
@@ -20,7 +20,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -71,9 +71,9 @@
      inkscape:object-nodes="true"
      inkscape:snap-center="true"
      inkscape:snap-object-midpoints="true"
-     inkscape:zoom="1.4047855"
-     inkscape:cx="573.13559"
-     inkscape:cy="87.92559"
+     inkscape:zoom="0.49666668"
+     inkscape:cx="280.63"
+     inkscape:cy="283.88869"
      inkscape:window-x="-9"
      inkscape:window-y="-9"
      inkscape:window-maximized="1"
@@ -108,21 +108,6 @@
      cy="139.04337"
      cx="307.07568"
      stroke-miterlimit="10" />
-  <circle
-     style="fill:#000000;stroke:#000000;stroke-width:6;stroke-miterlimit:10"
-     id="circle6876-6"
-     r="12"
-     cy="-139.04337"
-     cx="307.07568"
-     stroke-miterlimit="10"
-     transform="scale(1,-1)" />
-  <rect
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#a6cabe;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-     id="rect7954"
-     width="517.20721"
-     height="600"
-     x="682.79272"
-     y="0" />
   <path
      style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:5.22300005;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      d="M 39.813931,210.73338 C 46.75317,291.38166 179.1746,322.71887 303.81393,354.58636 v 0"
@@ -143,80 +128,97 @@
      y1="354.58636"
      x1="303.81393"
      stroke-miterlimit="10" />
-  <text
-     xml:space="preserve"
-     style="font-style:normal;font-weight:normal;font-size:21.33333397px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     x="696.64429"
-     y="36.241608"
-     id="text4519"><tspan
-       sodipodi:role="line"
-       id="tspan4517"
+  <g
+     id="instruction_IGNORE">
+    <rect
+       y="0"
+       x="682.79272"
+       height="600"
+       width="517.20721"
+       id="rect7954"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#a6cabe;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+    <text
+       id="text4519"
+       y="36.241608"
        x="696.64429"
-       y="36.241608">How to move things...</tspan></text>
-  <text
-     xml:space="preserve"
-     style="font-style:normal;font-weight:normal;font-size:32px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     x="694.82135"
-     y="130.60403"
-     id="text4523"><tspan
-       sodipodi:role="line"
-       x="694.82135"
+       style="font-style:normal;font-weight:normal;font-size:21.33333397px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       xml:space="preserve"><tspan
+         y="36.241608"
+         x="696.64429"
+         id="tspan4517"
+         sodipodi:role="line">How to move things...</tspan></text>
+    <text
+       id="text4523"
        y="130.60403"
-       id="tspan4547">Change the upper-right</tspan><tspan
-       sodipodi:role="line"
        x="694.82135"
-       y="170.60403"
-       id="tspan4553">end of the green line.</tspan></text>
-  <text
-     xml:space="preserve"
-     style="font-style:normal;font-weight:normal;font-size:21.33333397px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     x="696.9151"
-     y="527.67151"
-     id="text4527"><tspan
-       sodipodi:role="line"
-       x="696.9151"
+       style="font-style:normal;font-weight:normal;font-size:32px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       xml:space="preserve"><tspan
+         id="tspan4547"
+         y="130.60403"
+         x="694.82135"
+         sodipodi:role="line">Change the upper-right</tspan><tspan
+         id="tspan4553"
+         y="170.60403"
+         x="694.82135"
+         sodipodi:role="line">end of the green line.</tspan></text>
+    <text
+       id="text4527"
        y="527.67151"
-       id="tspan4557">Try to make the lower-left corner </tspan><tspan
-       sodipodi:role="line"
        x="696.9151"
-       y="554.3382"
-       id="tspan4563">of the black box land here.</tspan></text>
-  <g
-     id="g4903"
-     transform="translate(0,20)">
-    <path
-       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-       d="m 624.43164,551.16016 v 2 h 126.8457 v -2 z"
-       id="path4561"
-       inkscape:connector-curvature="0" />
-    <path
-       d="m 634.89421,557.00155 -13.11106,-4.82126 13.11106,-4.82127 c -2.0946,2.84647 -2.08253,6.74094 0,9.64253 z"
-       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.75;stroke-linejoin:round;stroke-opacity:1"
-       id="path4909"
-       inkscape:connector-curvature="0" />
-  </g>
-  <text
-     xml:space="preserve"
-     style="font-style:normal;font-weight:normal;font-size:21.33333397px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     x="689.48157"
-     y="292.32388"
-     id="text4527-4"><tspan
-       sodipodi:role="line"
-       x="689.48157"
+       style="font-style:normal;font-weight:normal;font-size:21.33333397px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       xml:space="preserve"><tspan
+         id="tspan4557"
+         y="527.67151"
+         x="696.9151"
+         sodipodi:role="line">Try to make the lower-left corner </tspan><tspan
+         id="tspan4563"
+         y="554.3382"
+         x="696.9151"
+         sodipodi:role="line">of the black box land here.</tspan></text>
+    <g
+       transform="translate(0,20)"
+       id="g4903">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4561"
+         d="m 624.43164,551.16016 v 2 h 126.8457 v -2 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4909"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.75;stroke-linejoin:round;stroke-opacity:1"
+         d="m 634.89421,557.00155 -13.11106,-4.82126 13.11106,-4.82127 c -2.0946,2.84647 -2.08253,6.74094 0,9.64253 z" />
+    </g>
+    <text
+       id="text4527-4"
        y="292.32388"
-       id="tspan4563-6">Only change only this end.</tspan></text>
-  <g
-     transform="translate(-7.4335582,-281.34761)"
-     id="g4903-1">
-    <path
-       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-       d="m 624.43164,551.16016 v 2 h 126.8457 v -2 z"
-       id="path4561-5"
-       inkscape:connector-curvature="0" />
-    <path
-       d="m 634.89421,557.00155 -13.11106,-4.82126 13.11106,-4.82127 c -2.0946,2.84647 -2.08253,6.74094 0,9.64253 z"
-       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.75;stroke-linejoin:round;stroke-opacity:1"
-       id="path4909-3"
-       inkscape:connector-curvature="0" />
+       x="689.48157"
+       style="font-style:normal;font-weight:normal;font-size:21.33333397px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       xml:space="preserve"><tspan
+         id="tspan4563-6"
+         y="292.32388"
+         x="689.48157"
+         sodipodi:role="line">Only change only this end.</tspan></text>
+    <g
+       id="g4903-1"
+       transform="translate(-7.4335582,-281.34761)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4561-5"
+         d="m 624.43164,551.16016 v 2 h 126.8457 v -2 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4909-3"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.75;stroke-linejoin:round;stroke-opacity:1"
+         d="m 634.89421,557.00155 -13.11106,-4.82126 13.11106,-4.82127 c -2.0946,2.84647 -2.08253,6.74094 0,9.64253 z" />
+    </g>
   </g>
+  <circle
+     style="fill:#000000;stroke:#000000;stroke-width:6;stroke-miterlimit:10"
+     id="circle6876-2"
+     r="12"
+     cy="139.04337"
+     cx="307.07568"
+     stroke-miterlimit="10" />
 </svg>


### PR DESCRIPTION
Users should be prevented from using transformed elements (which visually appear in some location but are not detected by the engine there).

Ignore all elements with an id containing `"IGNORE"`, including their children.
Svgretrieve._exclude checks for tagnames (`defs`, `marker`) and ids that indicate to exclude a branch.